### PR TITLE
Updated deploy script to re-generate mypy stubs for --strict support.

### DIFF
--- a/scripts/deploy_webhook.py
+++ b/scripts/deploy_webhook.py
@@ -2,7 +2,6 @@ import os
 
 import requests
 
-
 if os.getenv("TRAVIS_TAG"):
     webhook_url = os.environ["DEPLOY_WEBHOOK_URL"]
     tag = os.environ["TRAVIS_TAG"]


### PR DESCRIPTION
Since MyPy cannot understand dynamically generated `__all__` in `--strict` mode, this will ensure users can still use `mypy --strict` with their applications without us hardcoding around 100 names into each package-level `__init__` module.