### PR TITLE
Amended 'BotApp.run' to not reraise exceptions caused by graceful shutdown.

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -676,17 +676,18 @@ class BotApp(
             loop.run_until_complete(self._shard_management_lifecycle())
 
         except KeyboardInterrupt as ex:
-            _LOGGER.info("received signal to shut down client")
+            _LOGGER.info("received OS signal to shut down client")
             if self._debug:
                 raise
             # The user will not care where this gets raised from, unless we are
             # debugging. It just causes a lot of confusing spam.
             raise ex.with_traceback(None) from None
 
+        except errors.GatewayClientClosedError:
+            _LOGGER.info("client shut itself down")
+
         finally:
             self._map_signal_handlers(loop.remove_signal_handler)
-            _LOGGER.info("client has shut down")
-
             if close_loop and not loop.is_closed():
                 _LOGGER.info("closing event loop")
                 loop.close()


### PR DESCRIPTION
This should reduce exception spam caused by invoking `await bot.close()` from a listener.

The application itself may still be raising other errors if you use a Windows proactor event loop, from what I have seen in other user's logs, but alas I cannot reproduce this currently.