### PR TITLE
Removed majority of `__all__` from root init.

### DIFF
--- a/hikari/__init__.py
+++ b/hikari/__init__.py
@@ -23,12 +23,10 @@
 
 To get started, you will want to initialize an instance of `Bot`
 (an alias for `hikari.impl.bot.BotApp`) for writing a bot, or `REST` (an
-alias for `hikari.impl.rest.RESTAppFactoryImpl`) if you only need to use
+alias for `hikari.impl.rest.RESTApp`) if you only need to use
 the REST API.
 """
 
-# We need these imported explicitly for the __all__ to be visible due to
-# Python's weird import visibility system.
 from hikari import config
 from hikari import errors
 from hikari import events
@@ -64,31 +62,4 @@ from hikari.utilities.undefined import UNDEFINED
 from hikari.utilities.undefined import UndefinedNoneOr
 from hikari.utilities.undefined import UndefinedOr
 
-_presorted_all = [
-    "File",
-    "Pathish",
-    "Rawish",
-    "LazyByteIteratorish",
-    "Resourceish",
-    "Snowflake",
-    "Snowflakeish",
-    "SnowflakeishOr",
-    "SearchableSnowflakeish",
-    "SearchableSnowflakeishOr",
-    "Unique",
-    "UNDEFINED",
-    "UndefinedOr",
-    "UndefinedNoneOr",
-    *config.__all__,
-    *events.__all__,
-    *errors.__all__,
-    *models.__all__,
-]
-
-# This may seem a bit dirty, but I have added an edge case to the documentation
-# logic to *ignore* the sorting member rules for the root `hikari` module
-# (this file) specifically. This way, we can force `Bot` and `RESTClientFactory`
-# to the top of the list.
-__all__ = ["Bot", "REST", *sorted(_presorted_all)]
-
-del _presorted_all
+__all__ = ["Bot", "REST"]


### PR DESCRIPTION
This is an experiment to see how this affects the documentation visibility-wise and how it impacts MyPy stubs that get generated.