### PR TITLE
Remove `or None` from documentation

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -86,7 +86,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.channels.PrivateTextChannel or builtins.None
+        typing.Optional[hikari.models.channels.PrivateTextChannel]
             The object of the private text channel that was found in the cache
             or `builtins.None`.
         """
@@ -112,7 +112,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.emojis.KnownCustomEmoji or builtins.None
+        typing.Optional[hikari.models.emojis.KnownCustomEmoji]
             The object of the emoji that was found in the cache or `builtins.None`.
         """
 
@@ -156,7 +156,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.GatewayGuild or builtins.None
+        typing.Optional[hikari.models.guilds.GatewayGuild]
             The object of the guild if found, else None.
         """
 
@@ -181,7 +181,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.channels.GuildChannel or builtins.None
+        typing.Optional[hikari.models.channels.GuildChannel]
             The object of the guild channel that was found in the cache or
             `builtins.None`.
         """
@@ -225,7 +225,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.invites.InvteWithMetadata or builtins.None
+        typing.Optional[hikari.models.invites.InvteWithMetadata]
             The object of the invite that was found in the cache or `builtins.None`.
         """
 
@@ -284,7 +284,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.users.OwnUser or builtins.None
+        typing.Optional[hikari.models.users.OwnUser]
             The own user object that was found in the cache, else `builtins.None`.
         """
 
@@ -301,7 +301,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.Member or builtins.None
+        typing.Optional[hikari.models.guilds.Member]
             The object of the member found in the cache, else `builtins.None`.
         """
 
@@ -348,7 +348,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.include_presences.MemberPresence or builtins.None
+        typing.Optional[hikari.models.include_presences.MemberPresence]
             The object of the presence that was found in the cache or
             `builtins.None`.
         """
@@ -395,7 +395,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.Role or builtins.None
+        typing.Optional[hikari.models.guilds.Role]
             The object of the role found in the cache or `builtins.None`.
         """
 
@@ -436,7 +436,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.users.User or builtins.None
+        typing.Optional[hikari.models.users.User]
             The object of the user that was found in the cache else `builtins.None`.
         """
 
@@ -465,7 +465,7 @@ class Cache(abc.ABC):
 
         Returns
         -------
-        hikari.models.voices.VoiceState or builtins.None
+        typing.Optional[hikari.models.voices.VoiceState]
             The object of the voice state that was found in the cache, or
             `builtins.None`.
         """
@@ -554,7 +554,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.channels.PrivateTextChannel or builtins.None
+        typing.Optional[hikari.models.channels.PrivateTextChannel]
             The object of the private text channel that was removed from the
             cache if found, else `builtins.None`
         """
@@ -582,7 +582,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.channels.PrivateTextChannel or builtins.None, hikari.models.channels.PrivateTextChannel or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.channels.PrivateTextChannel], typing.Optional[hikari.models.channels.PrivateTextChannel]]
             A tuple of the old cached private text channel if found
             (else `builtins.None`) and the new cached private text channel if it
             could be cached (else `builtins.None`).
@@ -641,7 +641,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.emojis.KnownCustomEmoji or builtins.None
+        typing.Optional[hikari.models.emojis.KnownCustomEmoji]
             The object of the emoji that was removed from the cache or
             `builtins.None`.
         """
@@ -669,7 +669,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.emojis.KnownCustomEmoji or builtins.None, hikari.models.emojis.KnownCustomEmoji or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.emojis.KnownCustomEmoji], typing.Optional[hikari.models.emojis.KnownCustomEmoji]]
             A tuple of the old cached emoji object if found (else `builtins.None`)
             and the new cached emoji object if it could be cached (else
             `builtins.None`).
@@ -697,7 +697,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.GatewayGuild or builtins.None
+        typing.Optional[hikari.models.guilds.GatewayGuild]
             The object of the guild that was removed from the cache, will be
             `builtins.None` if not found.
         """
@@ -741,7 +741,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.guilds.GatewayGuild or builtins.None, hikari.models.guilds.GatewayGuild or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.guilds.GatewayGuild], typing.Optional[hikari.models.guilds.GatewayGuild]]
             A tuple of the old cached guild object if found (else `builtins.None`)
             and the object of the guild that was added to the cache if it could
             be added (else `builtins.None`).
@@ -787,7 +787,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.channels.GuildChannel or builtins.None
+        typing.Optional[hikari.models.channels.GuildChannel]
             The object of the guild channel that was removed from the cache if
             found, else `builtins.None`.ww
         """
@@ -815,7 +815,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.channels.GuildChannel or builtins.None, hikari.models.channels.GuildChannel or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.channels.GuildChannel], typing.Optional[hikari.models.channels.GuildChannel]]
             A tuple of the old cached guild channel if found (else `builtins.None`)
             and the new cached guild channel if it could be cached
             (else `builtins.None`).
@@ -879,7 +879,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.invites.InviteWithMetaData or builtins.None
+        typing.Optional[hikari.models.invites.InviteWithMetaData]
             The object of the invite that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -907,7 +907,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.invites.InviteWithMetadata or builtins.None, hikari.models.invites.InviteWithMetadata or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.invites.InviteWithMetadata], typing.Optional[hikari.models.invites.InviteWithMetadata]]
             A tuple of the old cached invite object if found (else
             `builtins.None`) and the new cached invite object if it could be
             cached (else `builtins.None`).
@@ -919,7 +919,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.users.OwnUser or builtins.None
+        typing.Optional[hikari.models.users.OwnUser]
             The own user object that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -947,7 +947,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.users.OwnUser or builtins.None, hikari.models.users.OwnUser or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.users.OwnUser], typing.Optional[hikari.models.users.OwnUser]]
             A tuple of the old cached own user object if found (else
             `builtins.None`) and the new cached own user object if it could be
             cached, else `builtins.None`.
@@ -1006,7 +1006,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.Member or builtins.None
+        typing.Optional[hikari.models.guilds.Member]
             The object of the member that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -1034,7 +1034,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.guilds.Member or builtins.None, hikari.models.guilds.Member or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.guilds.Member], typing.Optional[hikari.models.guilds.Member]]
             A tuple of the old cached member object if found (else `builtins.None`)
             and the new cached member object if it could be cached (else
             `builtins.None`)
@@ -1086,7 +1086,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.include_presences.MemberPresence or builtins.None
+        typing.Optional[hikari.models.include_presences.MemberPresence]
             The object of the presence that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -1114,7 +1114,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.presence.MemberPresence or builtins.None, hikari.models.presence.MemberPresence or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.presence.MemberPresence], typing.Optional[hikari.models.presence.MemberPresence]]
             A tuple of the old cached invite object if found (else `builtins.None`
             and the new cached invite object if it could be cached ( else
             `builtins.None`).
@@ -1158,7 +1158,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.guilds.Role or builtins.None
+        typing.Optional[hikari.models.guilds.Role]
             The object of the role that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -1186,7 +1186,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.guilds.Role or builtins.None, hikari.models.guilds.Role or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.guilds.Role], typing.Optional[hikari.models.guilds.Role]]
             A tuple of the old cached role object if found (else `builtins.None`
             and the new cached role object if it could be cached (else
             `builtins.None`).
@@ -1224,7 +1224,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.users.User or builtins.None
+        typing.Optional[hikari.models.users.User]
             The object of the user that was removed from the cache if found,
             else `builtins.None`.
         """
@@ -1252,7 +1252,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.users.User or builtins.None, hikari.models.users.User or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.users.User], typing.Optional[hikari.models.users.User]]
             A tuple of the old cached user if found (else `builtins.None`) and
             the newly cached user if it could be cached (else `builtins.None`).
         """
@@ -1321,7 +1321,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        hikari.models.voices.VoiceState or builtins.None
+        typing.Optional[hikari.models.voices.VoiceState]
             The object of the voice state that was removed from the cache if
             found, else `builtins.None`.
         """
@@ -1349,7 +1349,7 @@ class MutableCache(Cache, abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.models.voices.VoiceState or builtins.None, hikari.models.voices.VoiceState or builtins.None]
+        typing.Tuple[typing.Optional[hikari.models.voices.VoiceState], typing.Optional[hikari.models.voices.VoiceState]]
             A tuple of the old cached voice state if found (else `builtins.None`)
             and the new cached voice state object if it could be cached
             (else `builtins.None`).

--- a/hikari/api/event_dispatcher.py
+++ b/hikari/api/event_dispatcher.py
@@ -247,7 +247,7 @@ class EventDispatcher(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[T] or builtins.None
+        event_type : typing.Optional[typing.Type[T]]
             The event type to subscribe to. The implementation may allow this
             to be undefined. If this is the case, the event type will be inferred
             instead from the type hints on the function signature.
@@ -290,7 +290,7 @@ class EventDispatcher(abc.ABC):
             return, or `builtins.False` if the event should not be returned.
             If left as `None` (the default), then the first matching event type
             that the bot receives (or any subtype) will be the one returned.
-        timeout : builtins.float or builtins.int or builtins.None
+        timeout : typing.Optional[builtins.float or builtins.int]
             The amount of time to wait before raising an `asyncio.TimeoutError`
             and giving up instead. This is measured in seconds. If
             `builtins.None`, then no timeout will be waited for (no timeout can

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1677,9 +1677,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        builtins.int or builtins.None
+        typing.Optional[builtins.int]
             If `compute_prune_count` is not provided or `builtins.True`, the
-            number of members pruned.
+            number of members pruned. Else `builtins.None`.
 
         Raises
         ------

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -83,7 +83,7 @@ class GatewayShard(abc.ABC):
 
         Returns
         -------
-        builtins.str or builtins.None
+        typing.Optional[builtins.str]
             The name of the compression method being used. Will be
             `builtins.None` if no compression is being used.
         """
@@ -172,7 +172,7 @@ class GatewayShard(abc.ABC):
 
         Returns
         -------
-        hikari.models.intents.Intents or builtins.None
+        typing.Optional[hikari.models.intents.Intents]
             The intents being used on this shard. This may be
             `builtins.None` if intents were not specified.
 
@@ -214,7 +214,7 @@ class GatewayShard(abc.ABC):
 
         Returns
         -------
-        builtins.int or builtins.None
+        typing.Optional[builtins.int]
             The session sequence, or `builtins.None` if no session is active.
         """
 
@@ -225,7 +225,7 @@ class GatewayShard(abc.ABC):
 
         Returns
         -------
-        builtins.str or builtins.None
+        typing.Optional[builtins.str]
             The session ID, or `builtins.None` if no session is active.
         """
 
@@ -339,7 +339,7 @@ class GatewayShard(abc.ABC):
         ----------
         guild : hikari.utilities.snowflake.SnowflakeishOr[hikari.models.guilds.PartialGuild]
             The guild or guild ID to update the voice state for.
-        channel : hikari.utilities.snowflake.SnowflakeishOr[hikari.models.channels.GuildVoiceChannel] or builtins.None
+        channel : typing.Optional[hikari.utilities.snowflake.SnowflakeishOr[hikari.models.channels.GuildVoiceChannel]]
             The channel or channel ID to update the voice state for. If `builtins.None`
             then the bot will leave the voice channel that it is in for the
             given guild.

--- a/hikari/config.py
+++ b/hikari/config.py
@@ -94,7 +94,7 @@ class ProxySettings:
 
         Returns
         -------
-        hikari.utilities.data_binding.Headers or builtins.None
+        typing.Optional[hikari.utilities.data_binding.Headers]
             Any headers that are set, or `builtins.None` if no headers are to
             be sent with any request.
         """

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -218,7 +218,7 @@ class ExceptionEvent(Event, typing.Generic[FailedEventT]):
 
         Returns
         -------
-        builtins.tuple[typing.Type[Exception], Exception, types.TracebackType or builtins.None]
+        builtins.tuple[typing.Type[Exception], Exception, typing.Optional[types.TracebackType]]
             The `sys.exc_info`-compatible tuple of the exception type, the
             exception instance, and the traceback of the exception.
         """

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -377,7 +377,7 @@ class PinsUpdateEvent(ChannelEvent, abc.ABC):
 
         Returns
         -------
-        datetime.datetime or builtins.None
+        typing.Optional[datetime.datetime]
             The datetime of the most recent pinned message in the channel,
             or `builtins.None` if no pins are available.
         """

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -412,7 +412,7 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
 
     Returns
     -------
-    hikari.models.users.PartialUser or builtins.None
+    typing.Optional[hikari.models.users.PartialUser]
         The partial user containing the updated fields.
     """
 
@@ -511,6 +511,6 @@ class MemberChunkEvent(shard_events.ShardEvent):
 
     Returns
     -------
-    builtins.str or builtins.None
+    typing.Optional[builtins.str]
         The request nonce if specified, or `builtins.None` otherwise.
     """

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -85,7 +85,7 @@ class BotApp(
 
     Parameters
     ----------
-    banner_package : builtins.str or builtins.None
+    banner_package : typing.Optional[builtins.str]
         The package to look for a `banner.txt` in. Will default to Hikari's
         banner if unspecified. If you set this to `builtins.None`, then no
         banner will be displayed.
@@ -99,7 +99,7 @@ class BotApp(
         The version of the gateway to connect to. At the time of writing,
         only version `6` and version `7` (undocumented development release)
         are supported. This defaults to using v6.
-    http_settings : hikari.config.HTTPSettings or builtins.None
+    http_settings : typing.Optional[hikari.config.HTTPSettings]
         The HTTP-related settings to use.
     initial_activity : typing.Optional[hikari.models.presences.Activity]
         The initial activity to have on each shard. Defaults to `builtins.None`.
@@ -112,7 +112,7 @@ class BotApp(
     initial_is_afk : builtins.bool
         If `builtins.True`, each shard will appear as being AFK on startup. If `builtins.False`,
         each shard will appear as _not_ being AFK. Defaults to `builtins.False`
-    intents : hikari.models.intents.Intents or builtins.None
+    intents : typing.Optional[hikari.models.intents.Intents]
         The intents to use for each shard. If `builtins.None`, then no intents
         are passed. Note that on the version `7` gateway, this will cause an
         immediate connection close with an error code.
@@ -128,7 +128,7 @@ class BotApp(
     large_threshold : builtins.int
         The number of members that need to be in a guild for the guild to be
         considered large. Defaults to the maximum, which is `250`.
-    logging_level : builtins.str or builtins.int or builtins.None
+    logging_level : typing.Optional[builtins.str or builtins.int]
         If not `builtins.None`, then this will be the logging level set if you
         have not enabled logging already. In this case, it should be a valid
         `logging` level that can be passed to `logging.basicConfig`. If you have
@@ -141,17 +141,17 @@ class BotApp(
             Initializing logging means already have a handler in the root
             logger. This is usually achieved by calling `logging.basicConfig`
             or adding the handler manually.
-    proxy_settings : hikari.config.ProxySettings or builtins.None
+    proxy_settings : typing.Optional[hikari.config.ProxySettings]
         Settings to use for the proxy.
     rest_version : int
         The version of the HTTP API to connect to. At the time of writing,
         only version `6` and version `7` (undocumented development release)
         are supported. This defaults to v6.
-    shard_ids : typing.AbstractSet[builtins.int] or builtins.None
+    shard_ids : typing.Optional[typing.AbstractSet[builtins.int]]
         A set of every shard ID that should be created and started on startup.
         If left to `builtins.None` along with `shard_count`, then auto-sharding
         is used instead, which is the default.
-    shard_count : builtins.int or builtins.None
+    shard_count : typing.Optional[builtins.int]
         The number of shards in the entire application. If left to
         `builtins.None` along with `shard_ids`, then auto-sharding is used
         instead, which is the default.
@@ -439,7 +439,7 @@ class BotApp(
 
         Returns
         -------
-        datetime.datetime or builtins.None
+        typing.Optional[datetime.datetime]
             The datetime that the bot connected at for the first time, or
             `builtins.None` if it has not yet connected.
         """

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -545,7 +545,7 @@ class RESTBucketManager:
         ----------
         compiled_route : hikari.utilities.routes.CompiledRoute
             The compiled _route to get the bucket for.
-        bucket_header : builtins.str or builtins.None
+        bucket_header : typing.Optional[builtins.str]
             The `X-RateLimit-Bucket` header that was provided in the response.
         remaining_header : builtins.int
             The `X-RateLimit-Remaining` header cast to an `builtins.int`.

--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -437,7 +437,7 @@ class ExponentialBackOff:
     ----------
     base : builtins.float
         The base to use. Defaults to `2`.
-    maximum : builtins.float or builtins.None
+    maximum : typing.Optional[builtins.float]
         If not `builtins.None`, then this is the max value the backoff can be
         in a single iteration before an `asyncio.TimeoutError` is raised.
         Defaults to `64` seconds.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -138,7 +138,7 @@ class RESTApp(traits.ExecutorAware):
 
     Parameters
     ----------
-    connector_factory : ConnectorFactory or builtins.None
+    connector_factory : typing.Optional[ConnectorFactory]
         A factory that produces an `aiohttp.BaseConnector` when requested.
 
         Defaults to a connector for a shared `aiohttp.TCPConnector` if
@@ -157,14 +157,14 @@ class RESTApp(traits.ExecutorAware):
         If `builtins.True`, then much more information is logged each time a
         request is made. Generally you do not need this to be on, so it will
         default to `builtins.False` instead.
-    executor : concurrent.futures.Executor or builtins.None
+    executor : typing.Optional[concurrent.futures.Executor]
         The executor to use for blocking file IO operations. If `builtins.None`
         is passed, then the default `concurrent.futures.ThreadPoolExecutor` for
         the `asyncio.AbstractEventLoop` will be used instead.
-    http_settings : hikari.config.HTTPSettings or builtins.None
+    http_settings : typing.Optional[hikari.config.HTTPSettings]
         HTTP settings to use. Sane defaults are used if this is
         `builtins.None`.
-    proxy_settings : hikari.config.ProxySettings or builtins.None
+    proxy_settings : typing.Optional[hikari.config.ProxySettings]
         Proxy settings to use. If `builtins.None` then no proxy configuration
         will be used.
     url : str or hikari.utilities.undefined.UndefinedType
@@ -291,7 +291,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     Parameters
     ----------
-    connector_factory : ConnectorFactory or builtins.None
+    connector_factory : typing.Optional[ConnectorFactory]
         A factory that produces an `aiohttp.BaseConnector` when requested.
 
         Defaults to a connector for a shared `aiohttp.TCPConnector` if
@@ -314,7 +314,7 @@ class RESTClientImpl(rest_api.RESTClient):
         left `builtins.False`.
     entity_factory : hikari.api.entity_factory.EntityFactory
         The entity factory to use.
-    executor : concurrent.futures.Executor or builtins.None
+    executor : typing.Optional[concurrent.futures.Executor]
         The executor to use for blocking IO. Defaults to the `asyncio` thread
         pool if set to `builtins.None`.
     token : hikari.utilities.undefined.UndefinedOr[builtins.str]

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -95,7 +95,7 @@ class GatewayShardImplV6(shard.GatewayShard):
     initial_status : hikari.models.presences.Status
         The initial status to set on login for the shard. Defaults to
         `hikari.models.presences.Status.ONLINE`.
-    intents : hikari.models.intents.Intents or builtins.None
+    intents : typing.Optional[hikari.models.intents.Intents]
         Collection of intents to use, or `builtins.None` to not use intents at
         all.
     large_threshold : builtins.int

--- a/hikari/models/applications.py
+++ b/hikari/models/applications.py
@@ -328,7 +328,7 @@ class Team(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no icon exists.
         """
         return self.format_icon()
@@ -348,7 +348,7 @@ class Team(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no icon exists.
 
         Raises
@@ -449,7 +449,7 @@ class Application(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no icon exists.
         """
         return self.format_icon()
@@ -469,7 +469,7 @@ class Application(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no icon exists.
 
         Raises
@@ -491,7 +491,7 @@ class Application(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no cover image exists.
         """
         return self.format_cover_image()
@@ -511,7 +511,7 @@ class Application(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no cover image exists.
 
         Raises

--- a/hikari/models/channels.py
+++ b/hikari/models/channels.py
@@ -470,7 +470,7 @@ class GroupPrivateTextChannel(PrivateChannel):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL, or `builtins.None` if no icon is present.
 
         Raises

--- a/hikari/models/embeds.py
+++ b/hikari/models/embeds.py
@@ -82,7 +82,7 @@ class EmbedResource(files.Resource[AsyncReaderT]):
 
         Parameters
         ----------
-        executor : concurrent.futures.Executor or builtins.None
+        executor : typing.Optional[concurrent.futures.Executor]
             The executor to run in for blocking operations.
             If `builtins.None`, then the default executor is used for the
             current event loop.
@@ -394,7 +394,7 @@ class Embed:
 
         Returns
         -------
-        hikari.models.colors.Color or builtins.None
+        typing.Optional[hikari.models.colors.Color]
             The colour that is set.
         """
         return self._color
@@ -414,7 +414,7 @@ class Embed:
 
         Returns
         -------
-        datetime.datetime or builtins.None
+        typing.Optional[datetime.datetime]
             The timestamp set on the embed.
 
         !!! warning
@@ -534,7 +534,7 @@ class Embed:
 
         Will be `builtins.None` if not set.
 
-        EmbedFooter or builtins.None
+        typing.Optional[EmbedFooter]
             The footer of the embed.
         """
         return self._footer
@@ -545,7 +545,7 @@ class Embed:
 
         Will be `builtins.None` if not set.
 
-        EmbedImage or builtins.None
+        typing.Optional[EmbedImage]
             The image of the embed.
 
         !!! note
@@ -559,7 +559,7 @@ class Embed:
 
         Will be `builtins.None` if not set.
 
-        EmbedImage or builtins.None
+        typing.Optional[EmbedImage]
             The thumbnail of the embed.
 
         !!! note
@@ -575,7 +575,7 @@ class Embed:
 
         Returns
         -------
-        EmbedVideo or builtins.None
+        typing.Optional[EmbedVideo]
             The video of the embed.
 
         !!! note
@@ -594,7 +594,7 @@ class Embed:
 
         Returns
         -------
-        EmbedProvider or builtins.None
+        typing.Optional[EmbedProvider]
             The provider of the embed.
 
         !!! note
@@ -613,7 +613,7 @@ class Embed:
 
         Returns
         -------
-        EmbedAuthor or builtins.None
+        typing.Optional[EmbedAuthor]
             The author of the embed.
 
         !!! note
@@ -642,11 +642,11 @@ class Embed:
 
         Parameters
         ----------
-        name : builtins.str or builtins.None
+        name : typing.Optional[builtins.str]
             The optional name of the author.
-        url : builtins.str or builtins.None
+        url : typing.Optional[builtins.str]
             The optional URL of the author.
-        icon : hikari.utilities.files.Resourceish or builtins.None
+        icon : typing.Optional[hikari.utilities.files.Resourceish]
             The optional image to show next to the embed author.
 
             This can be many different things, to aid in convenience.
@@ -691,10 +691,10 @@ class Embed:
 
         Parameters
         ----------
-        text : str or builtins.None
+        text : typing.Optional[str]
             The mandatory text string to set in the footer.
             If `builtins.None`, the footer is removed.
-        icon : hikari.utilities.files.Resourceish or builtins.None
+        icon : typing.Optional[hikari.utilities.files.Resourceish]
             The optional image to show next to the embed footer.
 
             This can be many different things, to aid in convenience.
@@ -744,7 +744,7 @@ class Embed:
 
         Parameters
         ----------
-        image : hikari.utilities.files.Resourceish or builtins.None
+        image : typing.Optional[hikari.utilities.files.Resourceish]
             The optional resource to show for the embed image.
 
             This can be many different things, to aid in convenience.
@@ -784,7 +784,7 @@ class Embed:
 
         Parameters
         ----------
-        image : hikari.utilities.files.Resourceish or builtins.None
+        image : typing.Optional[hikari.utilities.files.Resourceish]
             The optional resource to show for the embed thumbnail.
 
             This can be many different things, to aid in convenience.

--- a/hikari/models/guilds.py
+++ b/hikari/models/guilds.py
@@ -650,7 +650,7 @@ class PartialGuild(snowflake.Unique):
 
         Parameters
         ----------
-        format_ : builtins.str or builtins.None
+        format_ : typing.Optional[builtins.str]
             The format to use for this URL, defaults to `png` or `gif`.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
@@ -663,7 +663,7 @@ class PartialGuild(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL to the resource, or `builtins.None` if no icon is set.
 
         Raises
@@ -726,7 +726,7 @@ class GuildPreview(PartialGuild):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL to the splash, or `builtins.None` if not set.
 
         Raises
@@ -760,7 +760,7 @@ class GuildPreview(PartialGuild):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The string URL.
 
         Raises
@@ -966,7 +966,7 @@ class Guild(PartialGuild, abc.ABC):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL to the splash, or `builtins.None` if not set.
 
         Raises
@@ -1000,7 +1000,7 @@ class Guild(PartialGuild, abc.ABC):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The string URL.
 
         Raises
@@ -1034,7 +1034,7 @@ class Guild(PartialGuild, abc.ABC):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL of the banner, or `builtins.None` if no banner is set.
 
         Raises
@@ -1198,7 +1198,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        Role or builtins.None
+        typing.Optional[Role]
             The object of the role found in cache, else `builtins.None`.
         """
         return self.app.cache.get_role(snowflake.Snowflake(role))
@@ -1215,7 +1215,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        hikari.models.emojis.KnownCustomEmoji or builtins.None
+        typing.Optional[hikari.models.emojis.KnownCustomEmoji]
             The object of the custom emoji if found in cache, else
             `builtins.None`.
         """
@@ -1233,7 +1233,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        hikari.models.channels.GuildChannel or builtins.None
+        typing.Optional[hikari.models.channels.GuildChannel]
             The object of the guild channel found in cache or `builtins.None.
         """
         return self.app.cache.get_guild_channel(snowflake.Snowflake(channel))
@@ -1248,7 +1248,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        Member or builtins.None
+        typing.Optional[Member]
             The cached member object if found, else `builtins.None`.
         """
         return self.app.cache.get_member(self.id, snowflake.Snowflake(user))
@@ -1263,7 +1263,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        hikari.models.include_presences.MemberPresence or builtins.None
+        typing.Optional[hikari.models.include_presences.MemberPresence]
             The cached presence object if found, else `builtins.None`.
         """
         return self.app.cache.get_presence(self.id, snowflake.Snowflake(user))
@@ -1278,7 +1278,7 @@ class GatewayGuild(Guild):
 
         Returns
         -------
-        hikari.models.voice.VoiceState or builtins.None
+        typing.Optional[hikari.models.voice.VoiceState]
             The cached voice state object if found, else `builtins.None`.
         """
         return self.app.cache.get_voice_state(self.id, snowflake.Snowflake(user))

--- a/hikari/models/invites.py
+++ b/hikari/models/invites.py
@@ -150,7 +150,7 @@ class InviteGuild(guilds.PartialGuild):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL to the splash, or `builtins.None` if not set.
 
         Raises
@@ -184,7 +184,7 @@ class InviteGuild(guilds.PartialGuild):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL of the banner, or `builtins.None` if no banner is set.
 
         Raises

--- a/hikari/models/users.py
+++ b/hikari/models/users.py
@@ -250,7 +250,7 @@ class User(PartialUser, abc.ABC):
 
         Parameters
         ----------
-        format : builtins.str or builtins.None
+        format : typing.Optional[builtins.str]
             The format to use for this URL, defaults to `png` or `gif`.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated). Will be ignored for default avatars which can only be
@@ -265,7 +265,7 @@ class User(PartialUser, abc.ABC):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL to the avatar, or `builtins.None` if not present.
 
         Raises

--- a/hikari/models/webhooks.py
+++ b/hikari/models/webhooks.py
@@ -433,7 +433,7 @@ class Webhook(snowflake.Unique):
 
         Returns
         -------
-        hikari.utilities.files.URL or builtins.None
+        typing.Optional[hikari.utilities.files.URL]
             The URL of the resource. `builtins.None` if no avatar is set (in
             this case, use the `default_avatar` instead).
 

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -205,7 +205,7 @@ class ExecutorAware(typing.Protocol):
 
         Returns
         -------
-        concurrent.futures.Executor or builtins.None
+        typing.Optional[concurrent.futures.Executor]
             The executor to use, or `builtins.None` to use the `asyncio` default
             instead.
         """
@@ -344,7 +344,7 @@ class ShardAware(NetworkSettingsAware, ExecutorAware, CacheAware, ChunkerAware, 
 
         Returns
         -------
-        hikari.models.intents.Intent or builtins.None
+        typing.Optional[hikari.models.intents.Intent]
             The intents registered on this application.
         """
         raise NotImplementedError
@@ -360,7 +360,7 @@ class ShardAware(NetworkSettingsAware, ExecutorAware, CacheAware, ChunkerAware, 
 
         Returns
         -------
-        hikari.models.users.OwnUser or builtins.None
+        typing.Optional[hikari.models.users.OwnUser]
             The bot user, if known, otherwise `builtins.None`.
         """
         raise NotImplementedError

--- a/hikari/utilities/attr_extensions.py
+++ b/hikari/utilities/attr_extensions.py
@@ -223,7 +223,7 @@ def deep_copy_attrs(model: ModelT, memo: typing.Optional[typing.MutableMapping[i
     ----------
     model : ModelT
         The attrs model to deep copy.
-    memo : typing.MutableMapping[builtins.int, typing.Any] or builtins.None
+    memo : typing.Optional[typing.MutableMapping[builtins.int, typing.Any]]
         A memo dictionary of objects already copied during the current copying
         pass, see https://docs.python.org/3/library/copy.html for more details.
 

--- a/hikari/utilities/data_binding.py
+++ b/hikari/utilities/data_binding.py
@@ -129,7 +129,7 @@ class StringMapBuilder(multidict.MultiDict[str]):
             The string key.
         value : hikari.utilities.undefined.UndefinedOr[typing.Any]
             The value to set.
-        conversion : typing.Callable[[typing.Any], typing.Any] or builtins.None
+        conversion : typing.Optional[typing.Callable[[typing.Any], typing.Any]]
             An optional conversion to perform.
 
         !!! note
@@ -199,7 +199,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             The JSON type to put. This may be a non-JSON type if a conversion
             is also specified. This may alternatively be undefined. In the latter
             case, nothing is performed.
-        conversion : typing.Callable[[typing.Any], JSONish] or builtins.None
+        conversion : typing.Optional[typing.Callable[[typing.Any], JSONish]]
             Optional conversion to apply.
         """
         if value is not undefined.UNDEFINED:
@@ -230,7 +230,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             The JSON types to put. This may be an iterable of non-JSON types if
             a conversion is also specified. This may alternatively be undefined.
             In the latter case, nothing is performed.
-        conversion : typing.Callable[[typing.Any], JSONType] or builtins.None
+        conversion : typing.Optional[typing.Callable[[typing.Any], JSONType]]
             Optional conversion to apply.
         """
         if values is not undefined.UNDEFINED:
@@ -240,7 +240,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
                 self[key] = list(values)
 
     def put_snowflake(
-        self, key: str, value: typing.Optional[undefined.UndefinedOr[snowflake.SnowflakeishOr[snowflake.Unique]]], /
+        self, key: str, value: undefined.UndefinedNoneOr[snowflake.SnowflakeishOr[snowflake.Unique]], /
     ) -> None:
         """Put a key with a snowflake value into the builder.
 
@@ -248,7 +248,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
         ----------
         key : builtins.str
             The key to give the element.
-        value : hikari.utilities.snowflake.Snowflakeish or hikari.utilities.undefined.UndefinedType or None
+        value : hikari.undefined.UndefinedNoneOr[hikari.utilities.snowflake.SnowflakeishOr[hikari.utilities.snowflake.Unique]]
             The JSON type to put. This may alternatively be undefined, in this
             case, nothing is performed. This may also be `builtins.None`, in this
             case the value isn't cast.
@@ -271,10 +271,10 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
         ----------
         key : builtins.str
             The key to give the element.
-        values : typing.Iterable[typing.SupportsInt] or hikari.utilities.undefined.UndefinedType
+        values : hikari.utilities.undefined.UndefinedOr[typing.Iterable[hikari.utilities.snowflake.SnowflakeishOr[hikari.utilities.snowflake.Unique]]]
             The JSON snowflakes to put. This may alternatively be undefined.
             In the latter case, nothing is performed.
-        """
+        """  # noqa: E501 - Line too long
         if values is not undefined.UNDEFINED:
             self[key] = [str(int(value)) for value in values]
 

--- a/hikari/utilities/files.py
+++ b/hikari/utilities/files.py
@@ -174,7 +174,7 @@ def ensure_resource(url_or_resource: Resourceish, /) -> Resource[AsyncReader]:
 
     Returns
     -------
-    Resource or builtins.None
+    typing.Optional[Resource]
         The resource to use, or `builtins.None` if `builtins.None` was input.
     """
     if isinstance(url_or_resource, RAWISH_TYPES):
@@ -210,7 +210,7 @@ def guess_mimetype_from_filename(name: str, /) -> typing.Optional[str]:
 
     Returns
     -------
-    builtins.str or builtins.None
+    typing.Optional[builtins.str]
         The closest guess to the given filename. May be `builtins.None` if
         no match was found.
     """
@@ -232,7 +232,7 @@ def guess_mimetype_from_data(data: bytes, /) -> typing.Optional[str]:
 
     Returns
     -------
-    builtins.str or builtins.None
+    typing.Optional[builtins.str]
         The mimetype, if it was found. If the header is unrecognised, then
         `builtins.None` is returned.
     """
@@ -264,7 +264,7 @@ def guess_file_extension(mimetype: str) -> typing.Optional[str]:
 
     Returns
     -------
-    builtins.str or builtins.None
+    typing.Optional[builtins.str]
         The file extension, prepended with a `.`. If no match was found,
         return `builtins.None`.
     """
@@ -281,11 +281,11 @@ def generate_filename_from_details(
 
     Parameters
     ----------
-    mimetype : builtins.str or builtins.None
+    mimetype : typing.Optional[builtins.str]
         The mimetype of the content, or `builtins.None` if not known.
-    extension : builtins.str or builtins.None
+    extension : typing.Optional[builtins.str]
         The file extension to use, or `builtins.None` if not known.
-    data : builtins.bytes or builtins.None
+    data : typing.Optional[builtins.bytes]
         The data to inspect, or `builtins.None` if not known.
 
     Returns
@@ -315,7 +315,7 @@ def to_data_uri(data: bytes, mimetype: typing.Optional[str]) -> str:
     ----------
     data : builtins.bytes
         The data to encode as base64.
-    mimetype : builtins.str or builtins.None
+    mimetype : typing.Optional[builtins.str]
         The mimetype, or `builtins.None` if we should attempt to guess it.
 
     Returns
@@ -426,7 +426,7 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
 
         Parameters
         ----------
-        executor : concurrent.futures.Executor or builtins.None
+        executor : typing.Optional[concurrent.futures.Executor]
             The executor to run in for blocking operations.
             If `builtins.None`, then the default executor is used for the
             current event loop.
@@ -594,7 +594,7 @@ class WebResource(Resource[WebReader], abc.ABC):
 
         Parameters
         ----------
-        executor : concurrent.futures.Executor or builtins.None
+        executor : typing.Optional[concurrent.futures.Executor]
             Not used. Provided only to match the underlying interface.
         head_only : builtins.bool
             Defaults to `builtins.False`. If `builtins.True`, then the
@@ -798,7 +798,7 @@ class File(Resource[FileReader]):
             This will all be performed as required in an executor to prevent
             blocking the event loop.
 
-    filename : builtins.str or builtins.None
+    filename : typing.Optional[builtins.str]
         The filename to use. If this is `builtins.None`, the name of the file is taken
         from the path instead.
     """
@@ -832,7 +832,7 @@ class File(Resource[FileReader]):
 
         Parameters
         ----------
-        executor : concurrent.futures.Executor or builtins.None
+        executor : typing.Optional[concurrent.futures.Executor]
             The executor to run the blocking read operations in. If
             `builtins.None`, the default executor for the running event loop
             will be used instead.
@@ -939,7 +939,7 @@ class Bytes(Resource[IteratorReader]):
         The raw data.
     filename : builtins.str
         The filename to use.
-    mimetype : builtins.str or builtins.None
+    mimetype : typing.Optional[builtins.str]
         The mimetype, or `builtins.None` if you do not wish to specify this.
         If not provided, then this will be generated from the file extension
         of the filename instead.
@@ -986,7 +986,7 @@ class Bytes(Resource[IteratorReader]):
 
         Parameters
         ----------
-        executor : concurrent.futures.Executor or builtins.None
+        executor : typing.Optional[concurrent.futures.Executor]
             Not used. Provided only to match the underlying interface.
         head_only : builtins.bool
             Not used. Provided only to match the underlying interface.
@@ -1007,7 +1007,7 @@ class Bytes(Resource[IteratorReader]):
         ----------
         data_uri : builtins.str
             The data URI to parse.
-        filename : builtins.str or builtins.None
+        filename : typing.Optional[builtins.str]
             Filename to use. If this is not provided, then this is generated
             instead.
 

--- a/hikari/utilities/iterators.py
+++ b/hikari/utilities/iterators.py
@@ -123,7 +123,7 @@ class AttrComparator(typing.Generic[ValueT]):
         `str.isupper`, for example).
     expected_value : typing.Any
         The expected value.
-    cast : typing.Callable[[ValueT], typing.Any] or builtins.None
+    cast : typing.Optional[typing.Callable[[ValueT], typing.Any]]
         Optional cast to perform on the input value when being called before
         comparing it to the expected value but after accessing the attribute.
     """

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,8 +41,8 @@ echo "-- Contents of ./dist --"
 ls -ahl dist
 
 echo "-- Checking generated dists --"
-python -m twine check dist/* 
-python -m twine upload --disable-progress-bar --skip-existing dist/* --non-interactive --repository-url https://upload.pypi.org/legacy/ 
+python -m twine check dist/*
+python -m twine upload --disable-progress-bar --skip-existing dist/* --non-interactive --repository-url https://upload.pypi.org/legacy/
 
 echo "===== SENDING WEBHOOK ====="
 python scripts/deploy_webhook.py


### PR DESCRIPTION
### Summary
Remove `or None` from documentation. Fixes wrong linking in documentation

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None
