### PR TITLE
Bugfixes for race conditions in starting multisharded bots, and debug…

### DIFF
--- a/hikari/utilities/aio.py
+++ b/hikari/utilities/aio.py
@@ -24,7 +24,6 @@
 from __future__ import annotations
 
 __all__: typing.Final[typing.List[str]] = [
-    "patch_slow_callback_detection",
     "completed_future",
     "is_async_iterator",
     "is_async_iterable",
@@ -35,47 +34,10 @@ import inspect
 import logging
 import typing
 
-from hikari.utilities import date
-
 T_co = typing.TypeVar("T_co", covariant=True)
 T_inv = typing.TypeVar("T_inv")
 
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger(__name__)
-
-
-@typing.no_type_check
-def patch_slow_callback_detection(duration: float = 0.5) -> None:
-    """Patches some asyncio internals to allow detection of slow callbacks.
-
-    Any callbacks that take more than the given `duration` will be logged.
-
-    Parameters
-    ----------
-    duration : float
-        The duration to wait for before classifying a task as being "slow".
-    """
-    _LOGGER.debug("setting slow callback duration for loop to %.0fms", duration * 1_000)
-
-    original_run = getattr(asyncio.Handle, "_run")
-
-    def stringify(self: asyncio.Handle) -> str:
-        if _LOGGER.isEnabledFor(logging.WARNING):
-            if isinstance(getattr(self._callback, "__self__", None), asyncio.Task):
-                return repr(self._callback.__self__)
-            return str(self._callback)
-        return ""
-
-    def run(self: asyncio.Handle) -> None:
-        """Instrumented runner."""
-        start = date.monotonic()
-        try:
-            original_run(self)
-        finally:
-            period = date.monotonic() - start
-            if period >= duration:
-                _LOGGER.warning("Callback %s blocked for %.1fms!", stringify(self), period * 1_000)
-
-    setattr(asyncio.Handle, "_run", run)
 
 
 def completed_future(result: typing.Optional[T_inv] = None, /) -> asyncio.Future[typing.Optional[T_inv]]:


### PR DESCRIPTION
… refactoring.

- Fixed bugs where if you sent a sigint or other signal before a shard connected but
  after starting the loop, it may get ignored leaving the bot in schrodingers box.
- Muted reaped task results that may have been raised from cancellations due to the
  event loop closing. Should fix some proactor event loop spam for Windows users too.
- Removed custom blocking time monitor and made the asyncio one able to be controlled
  in bot.run, this only is usable in debug mode now for performance.
- Moved customisation of coroutine tracking depth where supported to bot.run from
  bot.start.
- asyncio debug mode is now enabled in bot.run, not bot.start, meaning users who
  wish to have full control just can reimplement bot.run only now.
- Fixed documentation.

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
