### PR TITLE
Handling aiohttp.WSServerUpgradeError

### DIFF
--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -374,6 +374,18 @@ class TestRunOnceShielded:
         assert await client._run_once_shielded(client_session) is True
 
     @hikari_test_helpers.timeout()
+    async def test_WSServerHandshakeError_is_restartable(self, client, client_session):
+        error = aiohttp.WSServerHandshakeError(
+            mock.Mock(spec_set=aiohttp.RequestInfo),
+            history=(mock.Mock(spec_set=aiohttp.ClientResponse),),
+            status=520,
+            message="Discord returned a 520 which means they are broken",
+        )
+
+        client._run_once = mock.AsyncMock(side_effect=error)
+        assert await client._run_once_shielded(client_session) is True
+
+    @hikari_test_helpers.timeout()
     async def test_invalid_session_is_restartable(self, client, client_session):
         client._run_once = mock.AsyncMock(side_effect=shard.GatewayShardImpl._InvalidSession())
         assert await client._run_once_shielded(client_session) is True


### PR DESCRIPTION
Discord appears to be sending 520 HTTP status codes from the gateway at certain times, with no info indicating what it is.

Appears to be something Cloudflare can spit out if Discord fails to communicate a response to them correctly, apparently.

Assuming this is just a regression or something on their side, so I have added a handler that can log this correctly.