### PR TITLE
Gateway websocket closure forcing, and new missing test cases.

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -460,6 +460,7 @@ class GatewayShardImplV6(shard.GatewayShard):
                 # big sharded bots and waste a lot of time, so theres no reason to bother.
                 limit=1,
                 limit_per_host=1,
+                force_close=True,
             ),
             version=aiohttp.HttpVersion11,
             timeout=aiohttp.ClientTimeout(


### PR DESCRIPTION
Added a missing test case that inspects how the aiohttp ClientSession gets initialized.

The client session should now force the closure of the single connection connector pool once done with, which hopefully should reduce lingering connections that may affect shutdown times.