### PR TITLE
Remove, narrow and fixup some guild related fields

### DIFF
--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -705,7 +705,7 @@ class GuildPreview(PartialGuild):
     emojis: typing.Mapping[snowflakes.Snowflake, emojis_.KnownCustomEmoji] = attr.ib(eq=False, hash=False, repr=False)
     """The mapping of IDs to the emojis this guild provides."""
 
-    approximate_presence_count: int = attr.ib(eq=False, hash=False, repr=True)
+    approximate_active_member_count: int = attr.ib(eq=False, hash=False, repr=True)
     """The approximate amount of presences in this guild."""
 
     approximate_member_count: int = attr.ib(eq=False, hash=False, repr=True)
@@ -1075,21 +1075,11 @@ class RESTGuild(Guild):
     _emojis: typing.Mapping[snowflakes.Snowflake, emojis_.KnownCustomEmoji] = attr.ib(eq=False, hash=False, repr=False)
     """A mapping of emoji IDs to the objects of the emojis this guild provides."""
 
-    approximate_member_count: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
-    """The approximate number of members in the guild.
+    approximate_member_count: int = attr.ib(eq=False, hash=False, repr=False)
+    """The approximate number of members in the guild."""
 
-    This information will be provided by HTTP API calls fetching the guilds that
-    a bot account is in. For all other purposes, this should be expected to
-    remain `builtins.None`.
-    """
-
-    approximate_active_member_count: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
-    """The approximate number of members in the guild that are not offline.
-
-    This information will be provided by HTTP API calls fetching the guilds that
-    a bot account is in. For all other purposes, this should be expected to
-    remain `builtins.None`.
-    """
+    approximate_active_member_count: int = attr.ib(eq=False, hash=False, repr=False)
+    """The approximate number of members in the guild that are not offline."""
 
     max_presences: int = attr.ib(eq=False, hash=False, repr=False)
     """The maximum number of presences for the guild."""

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -867,18 +867,6 @@ class Guild(PartialGuild, abc.ABC):
     If the `GuildFeature.PUBLIC` feature is not defined, then this is `builtins.None`.
     """
 
-    max_presences: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
-    """The maximum number of presences for the guild.
-
-    If this is `builtins.None`, then the default value is used (currently 25000).
-    """
-
-    max_members: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
-    """The maximum number of members allowed in this guild.
-
-    This information may not be present, in which case, it will be `builtins.None`.
-    """
-
     max_video_channel_users: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
     """The maximum number of users allowed in a video channel together.
 
@@ -1102,6 +1090,12 @@ class RESTGuild(Guild):
     a bot account is in. For all other purposes, this should be expected to
     remain `builtins.None`.
     """
+
+    max_presences: int = attr.ib(eq=False, hash=False, repr=False)
+    """The maximum number of presences for the guild."""
+
+    max_members: int = attr.ib(eq=False, hash=False, repr=False)
+    """The maximum number of members allowed in this guild."""
 
     @property
     def roles(self) -> typing.Mapping[snowflakes.Snowflake, Role]:

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -51,6 +51,7 @@ from hikari import voices as voice_models
 from hikari import webhooks as webhook_models
 from hikari.api import entity_factory
 from hikari.utilities import attr_extensions
+from hikari.utilities import constants
 from hikari.utilities import data_binding
 from hikari.utilities import date
 
@@ -121,8 +122,6 @@ class _GuildFields(_PartialGuildFields):
     is_widget_enabled: typing.Optional[bool] = attr.ib()
     system_channel_flags: guild_models.GuildSystemChannelFlag = attr.ib()
     rules_channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    max_presences: typing.Optional[int] = attr.ib()
-    max_members: typing.Optional[int] = attr.ib()
     max_video_channel_users: typing.Optional[int] = attr.ib()
     vanity_url_code: typing.Optional[str] = attr.ib()
     description: typing.Optional[str] = attr.ib()
@@ -1126,7 +1125,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         widget_channel_id = payload.get("widget_channel_id")
         system_channel_id = payload["system_channel_id"]
         rules_channel_id = payload["rules_channel_id"]
-        max_presences = payload.get("max_presences")
         max_video_channel_users = (
             int(payload["max_video_channel_users"]) if "max_video_channel_users" in payload else None
         )
@@ -1155,8 +1153,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_widget_enabled=payload["widget_enabled"] if "widget_enabled" in payload else None,
             system_channel_flags=guild_models.GuildSystemChannelFlag(payload["system_channel_flags"]),
             rules_channel_id=snowflakes.Snowflake(rules_channel_id) if rules_channel_id is not None else None,
-            max_presences=int(max_presences) if max_presences is not None else None,
-            max_members=int(payload["max_members"]) if "max_members" in payload else None,
             max_video_channel_users=max_video_channel_users,
             vanity_url_code=payload["vanity_url_code"],
             description=payload["description"],
@@ -1175,6 +1171,13 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         approximate_active_member_count = (
             int(payload["approximate_presence_count"]) if "approximate_presence_count" in payload else None
         )
+        max_members = int(payload["max_members"])
+
+        raw_max_presences = payload["max_presences"]
+        if raw_max_presences is None:
+            max_presences = constants.DEFAULT_MAX_PRESENCES
+        else:
+            max_presences = int(raw_max_presences)
 
         roles = {
             snowflakes.Snowflake(role["id"]): self.deserialize_role(role, guild_id=guild_fields.id)
@@ -1206,8 +1209,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_widget_enabled=guild_fields.is_widget_enabled,
             system_channel_flags=guild_fields.system_channel_flags,
             rules_channel_id=guild_fields.rules_channel_id,
-            max_presences=guild_fields.max_presences,
-            max_members=guild_fields.max_members,
+            max_presences=max_presences,
+            max_members=max_members,
             max_video_channel_users=guild_fields.max_video_channel_users,
             vanity_url_code=guild_fields.vanity_url_code,
             description=guild_fields.description,
@@ -1251,8 +1254,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_widget_enabled=guild_fields.is_widget_enabled,
             system_channel_flags=guild_fields.system_channel_flags,
             rules_channel_id=guild_fields.rules_channel_id,
-            max_presences=guild_fields.max_presences,
-            max_members=guild_fields.max_members,
             max_video_channel_users=guild_fields.max_video_channel_users,
             vanity_url_code=guild_fields.vanity_url_code,
             description=guild_fields.description,

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -143,7 +143,7 @@ class _InviteFields:
     inviter: typing.Optional[user_models.User] = attr.ib()
     target_user: typing.Optional[user_models.User] = attr.ib()
     target_user_type: typing.Optional[invite_models.TargetUserType] = attr.ib()
-    approximate_presence_count: typing.Optional[int] = attr.ib()
+    approximate_active_member_count: typing.Optional[int] = attr.ib()
     approximate_member_count: typing.Optional[int] = attr.ib()
 
 
@@ -1110,7 +1110,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             splash_hash=payload["splash"],
             discovery_splash_hash=payload["discovery_splash"],
             emojis=emojis,
-            approximate_presence_count=int(payload["approximate_presence_count"]),
+            approximate_active_member_count=int(payload["approximate_presence_count"]),
             approximate_member_count=int(payload["approximate_member_count"]),
             description=payload["description"],
         )
@@ -1165,12 +1165,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     def deserialize_rest_guild(self, payload: data_binding.JSONObject) -> guild_models.RESTGuild:
         guild_fields = self._set_guild_attributes(payload)
-        approximate_member_count = (
-            int(payload["approximate_member_count"]) if "approximate_member_count" in payload else None
-        )
-        approximate_active_member_count = (
-            int(payload["approximate_presence_count"]) if "approximate_presence_count" in payload else None
-        )
+        approximate_member_count = int(payload["approximate_member_count"])
+        approximate_active_member_count = int(payload["approximate_presence_count"])
         max_members = int(payload["max_members"])
 
         raw_max_presences = payload["max_presences"]
@@ -1353,7 +1349,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         target_user_type = (
             invite_models.TargetUserType(payload["target_user_type"]) if "target_user_type" in payload else None
         )
-        approximate_presence_count = (
+        approximate_active_member_count = (
             int(payload["approximate_presence_count"]) if "approximate_presence_count" in payload else None
         )
         approximate_member_count = (
@@ -1368,7 +1364,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             inviter=self.deserialize_user(payload["inviter"]) if "inviter" in payload else None,
             target_user=self.deserialize_user(payload["target_user"]) if "target_user" in payload else None,
             target_user_type=target_user_type,
-            approximate_presence_count=approximate_presence_count,
+            approximate_active_member_count=approximate_active_member_count,
             approximate_member_count=approximate_member_count,
         )
 
@@ -1385,7 +1381,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             target_user=invite_fields.target_user,
             target_user_type=invite_fields.target_user_type,
             approximate_member_count=invite_fields.approximate_member_count,
-            approximate_presence_count=invite_fields.approximate_presence_count,
+            approximate_active_member_count=invite_fields.approximate_active_member_count,
         )
 
     def deserialize_invite_with_metadata(self, payload: data_binding.JSONObject) -> invite_models.InviteWithMetadata:
@@ -1402,7 +1398,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             target_user=invite_fields.target_user,
             target_user_type=invite_fields.target_user_type,
             approximate_member_count=invite_fields.approximate_member_count,
-            approximate_presence_count=invite_fields.approximate_presence_count,
+            approximate_active_member_count=invite_fields.approximate_active_member_count,
             uses=int(payload["uses"]),
             max_uses=int(payload["max_uses"]),
             max_age=datetime.timedelta(seconds=max_age) if max_age > 0 else None,

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -251,7 +251,7 @@ class Invite(InviteCode):
     target_user_type: typing.Optional[TargetUserType] = attr.ib(eq=False, hash=False, repr=False)
     """The type of user target this invite is, if applicable."""
 
-    approximate_presence_count: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
+    approximate_active_member_count: typing.Optional[int] = attr.ib(eq=False, hash=False, repr=False)
     """The approximate amount of presences in this invite's guild.
 
     This is only present when `with_counts` is passed as `builtins.True` to the GET

--- a/hikari/utilities/cache.py
+++ b/hikari/utilities/cache.py
@@ -434,7 +434,7 @@ class InviteData(BaseData[invites.InviteWithMetadata]):
         return super().build_entity(
             target,
             approximate_member_count=None,
-            approximate_presence_count=None,
+            approximate_active_member_count=None,
             channel=None,
             guild=None,
             **kwargs,

--- a/hikari/utilities/constants.py
+++ b/hikari/utilities/constants.py
@@ -81,4 +81,7 @@ CDN_URL: typing.Final[str] = "https://cdn.discordapp.com"
 TWEMOJI_PNG_BASE_URL: typing.Final[str] = "https://github.com/twitter/twemoji/raw/master/assets/72x72/"
 TWEMOJI_SVG_BASE_URL: typing.Final[str] = "https://github.com/twitter/twemoji/raw/master/assets/svg/"
 
+# Miscellaneous
+DEFAULT_MAX_PRESENCES: typing.Final[int] = 25000
+
 __all__: typing.Final[typing.List[str]] = [attr for attr in globals() if not any(c.islower() for c in attr)]

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -43,6 +43,7 @@ from hikari import users as user_models
 from hikari import voices as voice_models
 from hikari import webhooks as webhook_models
 from hikari.impl import entity_factory
+from hikari.utilities import constants
 
 
 def test__deserialize_seconds_timedelta():
@@ -1775,10 +1776,10 @@ class TestEntityFactoryImpl:
                 "system_channel_id": "19216801",
                 "vanity_url_code": "loool",
                 "verification_level": 4,
+                "max_presences": 8,
+                "max_members": 9,
             }
         )
-        assert guild.max_members is None
-        assert guild.max_presences is None
         assert guild.max_video_channel_users is None
         assert guild.premium_subscription_count is None
         assert guild.widget_channel_id is None
@@ -1836,7 +1837,7 @@ class TestEntityFactoryImpl:
         assert guild.widget_channel_id is None
         assert guild.system_channel_id is None
         assert guild.rules_channel_id is None
-        assert guild.max_presences is None
+        assert guild.max_presences is constants.DEFAULT_MAX_PRESENCES
         assert guild.vanity_url_code is None
         assert guild.description is None
         assert guild.banner_hash is None
@@ -1947,8 +1948,6 @@ class TestEntityFactoryImpl:
         assert guild.joined_at == datetime.datetime(2019, 5, 17, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
         assert guild.is_large is False
         assert guild.member_count == 14
-        assert guild.max_presences == 250
-        assert guild.max_members == 25000
         assert guild.max_video_channel_users == 25
         assert guild.vanity_url_code == "loool"
         assert guild.description == "This is a server I guess, its a bit crap though"
@@ -2034,8 +2033,6 @@ class TestEntityFactoryImpl:
         guild = guild_definition.guild
         assert guild.joined_at is None
         assert guild.is_large is None
-        assert guild.max_members is None
-        assert guild.max_presences is None
         assert guild.max_video_channel_users is None
         assert guild.member_count is None
         assert guild.premium_subscription_count is None
@@ -2103,7 +2100,6 @@ class TestEntityFactoryImpl:
         assert guild.widget_channel_id is None
         assert guild.system_channel_id is None
         assert guild.rules_channel_id is None
-        assert guild.max_presences is None
         assert guild.vanity_url_code is None
         assert guild.description is None
         assert guild.banner_hash is None

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1620,7 +1620,7 @@ class TestEntityFactoryImpl:
             )
         }
         assert guild_preview.approximate_member_count == 69
-        assert guild_preview.approximate_presence_count == 42
+        assert guild_preview.approximate_active_member_count == 42
         assert guild_preview.description == "A DESCRIPTION."
         assert isinstance(guild_preview, guild_models.GuildPreview)
 
@@ -1778,14 +1778,14 @@ class TestEntityFactoryImpl:
                 "verification_level": 4,
                 "max_presences": 8,
                 "max_members": 9,
+                "approximate_member_count": 42,
+                "approximate_presence_count": 9,
             }
         )
         assert guild.max_video_channel_users is None
         assert guild.premium_subscription_count is None
         assert guild.widget_channel_id is None
         assert guild.is_widget_enabled is None
-        assert guild.approximate_active_member_count is None
-        assert guild.approximate_active_member_count is None
 
     def test_deserialize_rest_guild_with_null_fields(self, entity_factory_impl):
         guild = entity_factory_impl.deserialize_rest_guild(
@@ -2178,19 +2178,24 @@ class TestEntityFactoryImpl:
         assert invite.target_user == entity_factory_impl.deserialize_user(alternative_user_payload)
         assert invite.target_user_type == invite_models.TargetUserType.STREAM
         assert invite.approximate_member_count == 84
-        assert invite.approximate_presence_count == 42
+        assert invite.approximate_active_member_count == 42
         assert isinstance(invite, invite_models.Invite)
 
     def test_deserialize_invite_with_null_and_unset_fields(self, entity_factory_impl, partial_channel_payload):
-        invite = entity_factory_impl.deserialize_invite({"code": "aCode", "channel_id": "43123123"})
+        invite = entity_factory_impl.deserialize_invite(
+            {
+                "code": "aCode",
+                "channel_id": "43123123",
+                "approximate_member_count": 231,
+                "approximate_presence_count": 9,
+            }
+        )
         assert invite.channel is None
         assert invite.channel_id == 43123123
         assert invite.guild is None
         assert invite.inviter is None
         assert invite.target_user is None
         assert invite.target_user_type is None
-        assert invite.approximate_presence_count is None
-        assert invite.approximate_member_count is None
 
     def test_deserialize_invite_with_guild_and_channel_ids_without_objects(self, entity_factory_impl):
         invite = entity_factory_impl.deserialize_invite({"code": "aCode", "guild_id": "42", "channel_id": "202020"})
@@ -2255,7 +2260,7 @@ class TestEntityFactoryImpl:
         assert invite_with_metadata.target_user == entity_factory_impl.deserialize_user(alternative_user_payload)
         assert invite_with_metadata.target_user_type == invite_models.TargetUserType.STREAM
         assert invite_with_metadata.approximate_member_count == 84
-        assert invite_with_metadata.approximate_presence_count == 42
+        assert invite_with_metadata.approximate_active_member_count == 42
         assert invite_with_metadata.uses == 3
         assert invite_with_metadata.max_uses == 8
         assert invite_with_metadata.max_age == datetime.timedelta(seconds=239349393)
@@ -2277,14 +2282,14 @@ class TestEntityFactoryImpl:
                 "max_age": 0,
                 "temporary": True,
                 "created_at": "2015-04-26T06:26:56.936000+00:00",
+                "approximate_presence_count": 4,
+                "approximate_member_count": 9,
             }
         )
         assert invite_with_metadata.guild is None
         assert invite_with_metadata.inviter is None
         assert invite_with_metadata.target_user is None
         assert invite_with_metadata.target_user_type is None
-        assert invite_with_metadata.approximate_presence_count is None
-        assert invite_with_metadata.approximate_member_count is None
 
     def test_max_age_when_zero(self, entity_factory_impl, invite_with_metadata_payload):
         invite_with_metadata_payload["max_age"] = 0

--- a/tests/hikari/impl/test_stateful_cache.py
+++ b/tests/hikari/impl/test_stateful_cache.py
@@ -939,7 +939,7 @@ class TestStatefulCacheImpl:
         assert invite.inviter is not mock_inviter
         assert invite.target_user is not mock_target_user
         assert invite.target_user_type is invites.TargetUserType.STREAM
-        assert invite.approximate_presence_count is None
+        assert invite.approximate_active_member_count is None
         assert invite.approximate_member_count is None
         assert invite.uses == 42
         assert invite.max_uses == 999


### PR DESCRIPTION
### Summary
* Removed dead max presences and members values from gateway guild.
* Fixed consistency for approx active member field naming between models.
* Narrow the scope of "with_count" only rest guild attributes to make them always required

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x ] I have run `nox` and all the pipelines have passed.
- [x ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
