### PR TITLE
Added optional `pip install hikari[speedups]` to get compiled modules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ _test_job: &test_job
     - ${PYTHON_COMMAND} -V
   script:
     - ${PYTHON_COMMAND} -m nox --sessions pytest
+    # Use --cov-append to make sure coverage covers speedup and non-speedup execution paths equally.
+    - ${PYTHON_COMMAND} -m nox --sessions pytest-speedups -- --cov-append
   after_script:
     - bash <(curl -s https://codecov.io/bash)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft hikari
 include LICENSE
 include requirements.txt
+include speedup-requirements.txt
 include setup.py
 include README.md
 include pyproject.toml

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ python -m pip install hikari -U --pre
 py -3 -m pip install hikari -U --pre
 ```
 
+If you have a C compiler (Microsoft VC++ Redis 14.0 or newer, or a modern copy
+of GCC/G++, Clang, etc), you can replace `hikari` with `hikari[speedups]` to
+download compiled versions of some dependencies in order to get a further
+performance boost.
+
 ----
 
 ## Additional libraries

--- a/pipelines/pytest.nox.py
+++ b/pipelines/pytest.nox.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """Py.test integration."""
+import os
 import shutil
 
 from pipelines import config
@@ -49,8 +50,19 @@ FLAGS = [
 def pytest(session: nox.Session) -> None:
     """Run unit tests and measure code coverage."""
     session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
+    _pytest(session)
+
+
+@nox.session(reuse_venv=True)
+def pytest_speedups(session: nox.Session) -> None:
+    """Run unit tests and measure code coverage, using speedup modules."""
+    session.install("-r", "requirements.txt", "-r", "speedup-requirements.txt", "-r", "dev-requirements.txt")
+    _pytest(session, "-OO")
+
+
+def _pytest(session: nox.Session, *py_flags: str) -> None:
     shutil.rmtree(".coverage", ignore_errors=True)
-    session.run("python", "-m", "pytest", *FLAGS, *session.posargs, config.TEST_PACKAGE)
+    session.run("python", *py_flags, "-m", "pytest", *FLAGS, *session.posargs, config.TEST_PACKAGE)
 
 
 @nox.inherit_environment_vars

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 aiohttp==3.6.2
 attrs==20.1.0
-ciso8601==2.1.3
 multidict==4.7.6

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=[name + "*"]),
     python_requires=">=3.8.0,<3.10",
     install_requires=parse_requirements_file("requirements.txt"),
+    extras_require={
+        "speedups": parse_requirements_file("speedup-requirements.txt"),
+    },
     include_package_data=True,
     test_suite="tests",
     zip_safe=False,

--- a/speedup-requirements.txt
+++ b/speedup-requirements.txt
@@ -1,0 +1,3 @@
+aiodns==2.0.0
+cchardet==2.1.6
+ciso8601==2.1.3


### PR DESCRIPTION
Without this, defaults are to use pure-Python implementations of stuff
where possible.

This fixes an issue where people without Visual C++ Redist 14.0 could not
install Hikari v2.0.0.dev74.

Fixes #116.
