### PR TITLE
Re-add normal twemoji session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,6 @@ jobs:
       os: linux
       arch: amd64
       install: "pip install nox"
-      if: env(DISCORD_EMOJI_MAPPING_URL) IS present
-      env:
-        - secure: "BjD5A9s8GCC/ighdYW143rLeKxs+ltNB6ibzMCEcKi+TffvMJ9oLbNM0q1jTs+Jw9YOzIr07d9hOTbc41IVQBqjwNzqBQo37dTp/JPLl1bI579gfOZJ5POg0AT+FX9VpM2qYVxNPYASX/2v03EVmtLEAVXdg37NnUzbx4H5BBjei9tcUOlhm7Mt0o5s4tx/XyNxfDNtUah4rg6FCvhaBza2oApiBxR/3dWEr4/pFLXXqh8fCtUfLtgv+zt8P4VZxgWn33hsfxuqqBattbK+aOaARHDvQe73p2xy9INWgmiKNcM1lgpiFGsgSa4HpfYo/oUqP/dLULUocloIPTqMHOpWcQSRHACd0UUkOv6ZiB63NahQOxAxOfPpIGLdf6JSb2huPNGgmg6gqewKHmRcqWghgJfnXoKKdKK3tFG8+jBbw0Rmi8NHg5xJVsfUDt8utkRceBb13WcirTdam9r/kWo5Ogy+jEdbDX5R8OFimq+uzDdsjnI+BuakphLScxW6wo+iibDOkIulsKk6xhgIXzCi1uT2KJkIBkX3zxNdRlMtZS7rC6uz3xgF4I9o756CiT85vlKBaQroBj/2fYfU+d2wYwVFtFVGopqVpTaSQidZaAVZzJNWTXov/aOAK/e55VwEssu22keS/p7g2+6dogUJjO+qswupB+dvcnVJlnNk="
       stage: test
       script:
         - python -m nox --sessions twemoji-test

--- a/scripts/test_twemoji_mapping.py
+++ b/scripts/test_twemoji_mapping.py
@@ -22,7 +22,6 @@
 by Discord emojis are actually legitimate URLs, since Discord
 does not map these on a 1-to-1 basis.
 """
-import os
 import pathlib
 import subprocess
 import sys
@@ -37,6 +36,7 @@ sys.path.append(".")
 from hikari import emojis
 
 TWEMOJI_REPO_BASE_URL = "https://github.com/twitter/twemoji.git"
+DISCORD_EMOJI_MAPPING_URL = "https://static.emzi0767.com/misc/discordEmojiMap.json"
 
 
 with tempfile.TemporaryDirectory() as tempdir:
@@ -44,12 +44,7 @@ with tempfile.TemporaryDirectory() as tempdir:
     valid_emojis = []
     invalid_emojis = []
 
-    try:
-        mapping_url = os.environ["DISCORD_EMOJI_MAPPING_URL"]
-    except KeyError:
-        raise RuntimeError("Please set the DISCORD_EMOJI_MAPPING_URL environment variable to the emoji map endpoint")
-
-    resp = requests.get(mapping_url)
+    resp = requests.get(DISCORD_EMOJI_MAPPING_URL)
     resp.encoding = "utf-8-sig"
     mapping = resp.json()["emojiDefinitions"]
 


### PR DESCRIPTION
This will allow the job to run every time the a pr is made to verify (permission granted by the owner of the mapping)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
