### PR TITLE
Wrote a massive pytest hack that lets us write mypy test cases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ credentials.env
 
 # Mypy Cache
 .mypy_cache/
+.dmypy.json
 
 # Profiling in pytest
 prof/

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -39,7 +39,6 @@ from hikari import config
 from hikari import errors
 from hikari import intents as intents_
 from hikari import presences
-from hikari import traits
 from hikari import users
 from hikari.api import cache as cache_
 from hikari.api import chunker as chunker_
@@ -85,7 +84,7 @@ or a capitalized string that matches one of `"DEBUG"`, `"INFO"`, `"WARNING"`,
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari")
 
 
-class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
+class BotApp(event_dispatcher.EventDispatcher):
     """Basic auto-sharding bot implementation.
 
     This is the class you will want to use to start, control, and build a bot
@@ -155,14 +154,14 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
         Defaults to `hikari.intents.Intents.ALL_UNPRIVILEGED`. This allows you
         to change which intents your application will use on the gateway. This
         can be used to control and change the types of events you will receive.
-    logs : typing.Union[builtins.None, LoggerLevel, typing.Dict[str, typing.Any]]
+    logs : typing.Union[builtins.None, LoggerLevelT, typing.Dict[str, typing.Any]]
         Defaults to `"INFO"`.
 
         If `builtins.None`, then the Python logging system is left uninitialized
         on startup, and you will need to configure it manually to view most
         logs that are output by components of this library.
 
-        If one of the valid values in a `LoggerLevel`, then this will match a
+        If one of the valid values in a `LoggerLevelT`, then this will match a
         call to `colorlog.basicConfig` (a facade for `logging.basicConfig` with
         additional conduit for enabling coloured logging levels) with the
         `level` kwarg matching this value.

--- a/pipelines/format.nox.py
+++ b/pipelines/format.nox.py
@@ -29,6 +29,7 @@ from pipelines import nox
 REFORMATING_PATHS = [
     "hikari",
     "tests",
+    "typesafety",
     "scripts",
     "pipelines",
     "setup.py",

--- a/typesafety/__init__.py
+++ b/typesafety/__init__.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import ast
+import atexit
+import functools
+import inspect
+import os
+import subprocess
+import tempfile
+import textwrap
+
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+tempdir = tempfile.TemporaryDirectory()
+atexit.register(tempdir.cleanup)
+
+
+def mypy_test(func):
+    """This makes me feel so dirty but I love it.
+
+    Extracts the source code from a decorated function using inspect, wraps
+    it in a coroutine definition and fires it off to a mypy daemon.
+    """
+
+    @functools.wraps(func)
+    def test(*_, **__):
+
+        # We use the AST to find out where the function definition ends and the
+        # function body starts. We then take the body and stick it in a fully
+        # typed coroutine function where we know we can await anything.
+        source_code = inspect.getsource(func)
+        lines = source_code.split("\n")
+        tree = ast.parse(source_code)
+        first_line = tree.body[0].body[0].lineno
+        body = "async def test() -> None:\n" + "\n".join(lines[first_line - 1 :])
+
+        test_file = os.path.join(tempdir.name, func.__name__ + ".py")
+        with open(test_file, "w") as fp:
+            fp.write(body)
+
+        proc = subprocess.Popen(["dmypy", "run", test_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate(None)
+        if proc.returncode != 0:
+            raise AssertionError(
+                "\n".join(
+                    (
+                        f"MyPy exited with status code {proc.returncode}",
+                        "",
+                        "STDOUT:",
+                        textwrap.indent(stdout.decode("utf-8"), "    "),
+                        "",
+                        "STDERR:",
+                        textwrap.indent(stderr.decode("utf-8"), "    "),
+                        "",
+                    )
+                )
+            )
+
+    return test

--- a/typesafety/hikari/__init__.py
+++ b/typesafety/hikari/__init__.py
@@ -18,21 +18,3 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from pipelines import config
-from pipelines import nox
-
-
-@nox.session(reuse_venv=True)
-def mypy(session: nox.Session) -> None:
-    """Perform static type analysis on Python source code."""
-    session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
-    session.run(
-        "mypy",
-        "-p",
-        config.MAIN_PACKAGE,
-        "--config",
-        config.MYPY_INI,
-    )
-    print("Running MyPy typeshed tests")
-    session.run("pytest", "typesafety")

--- a/typesafety/hikari/impl/__init__.py
+++ b/typesafety/hikari/impl/__init__.py
@@ -18,21 +18,3 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from pipelines import config
-from pipelines import nox
-
-
-@nox.session(reuse_venv=True)
-def mypy(session: nox.Session) -> None:
-    """Perform static type analysis on Python source code."""
-    session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
-    session.run(
-        "mypy",
-        "-p",
-        config.MAIN_PACKAGE,
-        "--config",
-        config.MYPY_INI,
-    )
-    print("Running MyPy typeshed tests")
-    session.run("pytest", "typesafety")

--- a/typesafety/hikari/impl/test_bot.py
+++ b/typesafety/hikari/impl/test_bot.py
@@ -18,21 +18,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from pipelines import config
-from pipelines import nox
+from typesafety import mypy_test
 
 
-@nox.session(reuse_venv=True)
-def mypy(session: nox.Session) -> None:
-    """Perform static type analysis on Python source code."""
-    session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
-    session.run(
-        "mypy",
-        "-p",
-        config.MAIN_PACKAGE,
-        "--config",
-        config.MYPY_INI,
-    )
-    print("Running MyPy typeshed tests")
-    session.run("pytest", "typesafety")
+@mypy_test
+def test_BotApp_is_subtype_of_BotAware():
+    from hikari import traits
+    from hikari.impl import bot
+
+    _: traits.BotAware = bot.BotApp("1234")


### PR DESCRIPTION
Lets us write tests to assert things like structural subtyping is valid (i.e. BotApp implements the traits.BotAware interface fully in MyPy).

Works by scraping the test function body that is decorated out of the function and sending it to a mypy daemon server for inspection.

Test cases take around 100ms to run on this once it has started, as opposed to like 5-20 seconds if we invoked MyPy directly.

---

May or may not merge this, just wanted to play with the idea and see if I got anywhere with it.