### PR TITLE
Fixed a logic error in websocket init logic

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -247,16 +247,15 @@ class _V6GatewayTransport(aiohttp.ClientWebSocketResponse):
                             raise errors.GatewayError(f"Unexpected {type(ex).__name__}: {ex}") from ex
                         finally:
                             if ws.closed:
-                                return
+                                ws._logger.debug("ws was already closed")
 
-                            if raised:
+                            elif raised:
                                 await ws.close(
                                     code=errors.ShardCloseCode.UNEXPECTED_CONDITION,
                                     message=b"unexpected fatal client error :-(",
                                 )
-                                return
 
-                            if not ws._closing:
+                            elif not ws._closing:
                                 # We use a special close code here that prevents Discord
                                 # randomly invalidating our session. Undocumented behaviour is
                                 # nice like that...

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -247,7 +247,7 @@ class _V6GatewayTransport(aiohttp.ClientWebSocketResponse):
                             raise errors.GatewayError(f"Unexpected {type(ex).__name__}: {ex}") from ex
                         finally:
                             if ws.closed:
-                                ws._logger.debug("ws was already closed")
+                                logger.debug("ws was already closed")
 
                             elif raised:
                                 await ws.close(


### PR DESCRIPTION
This caused exceptions to be discarded if the websocket had already cloesd, causing an infinite restart loop as the gateway shard would assume the connection closed without a reason when passing invalid intents, for example.