### PR TITLE
avoid the shard ratelimits delaying event dispatch

### DIFF
--- a/hikari/impl/stateful_event_manager.py
+++ b/hikari/impl/stateful_event_manager.py
@@ -168,7 +168,8 @@ class StatefulEventManagerImpl(event_manager_base.EventManagerBase):
         # to chunk small guilds.
         if (event.guild.is_large or not presences_declared) and members_declared:
             # We create a task here instead of awaiting the result to avoid any rate-limits from delaying dispatch.
-            asyncio.create_task(shard.request_guild_members(event.guild))
+            coroutine = shard.request_guild_members(event.guild)
+            asyncio.create_task(coroutine, name=f"{event.shard.id}:{event.guild.id} guild create members request")
 
         await self.dispatch(event)
 

--- a/hikari/impl/stateful_event_manager.py
+++ b/hikari/impl/stateful_event_manager.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 __all__: typing.Final[typing.List[str]] = ["StatefulEventManagerImpl"]
 
+import asyncio
 import typing
 
 from hikari import channels
@@ -166,7 +167,8 @@ class StatefulEventManagerImpl(event_manager_base.EventManagerBase):
         # payload if presence intents are also declared, so if this isn't the case then we also want
         # to chunk small guilds.
         if (event.guild.is_large or not presences_declared) and members_declared:
-            await shard.request_guild_members(event.guild)
+            # We create a task here instead of awaiting the result to avoid any rate-limits from delaying dispatch.
+            asyncio.create_task(shard.request_guild_members(event.guild))
 
         await self.dispatch(event)
 

--- a/tests/hikari/hikari_test_helpers.py
+++ b/tests/hikari/hikari_test_helpers.py
@@ -267,3 +267,8 @@ def assert_does_not_raise(type_=BaseException):
         return decorator(decorated_func)
     else:
         return decorator
+
+
+async def gather_all_tasks():
+    """Ensure all created tasks except the current are finished before asserting anything."""
+    await asyncio.gather(*(task for task in asyncio.all_tasks() if task is not asyncio.current_task()))


### PR DESCRIPTION
### Summary
shard.request_guild_members in places to avoid it blocking other stuff unnecessarily.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x ] I have run `nox` and all the pipelines have passed.
- [ x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
