### PR TITLE
Added logic to debug flows to remove tokens from output debug logs.

### DIFF
--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -810,7 +810,7 @@ class TestRESTClientImplAsync:
             status = http.HTTPStatus.OK
             content_type = constants.APPLICATION_JSON
             reason = "cause why not"
-            raw_headers = ((b"HEADER", b"value"), (b"HEADER", b"value"))
+            headers = {"HEADER": "value", "HEADER": "value"}
 
             async def read(self):
                 return '{"something": null}'


### PR DESCRIPTION
This will allow users to post debug logs in issues safely without leaking
credentials by accident, especially where logs are very long and may
result in tokens being missed.

New REST format:

```
# Req
    User-Agent: DiscordBot (https://github.com/nekokatt/hikari, 2.0.0) Nekokatt AIOHTTP/3.6.2 CPython/3.8.5 Linux 64bit
    X-RateLimit-Precision: millisecond
    Authorization: **REDACTED TOKEN**

# Resp
    Date: Tue, 08 Sep 2020 08:15:59 GMT
    Content-Type: application/json
    Transfer-Encoding: chunked
    Connection: keep-alive
    Set-Cookie: __cfduid=xxx, expires=Thu, 08-Oct-20 08:15:59 GMT; path=/; domain=.discord.com; HttpOnly; SameSite=Lax; Secure
    strict-transport-security: max-age=31536000; includeSubDomains; preload
    x-ratelimit-bucket: xxx
    x-ratelimit-limit: 2
    x-ratelimit-remaining: 1
    x-ratelimit-reset: 1599552964.170
    x-ratelimit-reset-after: 5.000
    content-encoding: gzip
    x-envoy-upstream-service-time: 10
    Via: 1.1 google
    CF-Cache-Status: DYNAMIC
    cf-request-id: xxx
    Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
    X-Content-Type-Options: nosniff
    Server: cloudflare
    CF-RAY: xxx-LHR

    {"url": "wss://gateway.discord.gg", "shards": 1, "session_start_limit": {"total": 1000, "remaining": 996, "reset_after": 85844266, "max_concurrency": 1}}
```

New GW format

```
    {"op": 2, "d": {"token": "**REDACTED TOKEN**", "compress": false, "large_threshold": 250, "properties": {"$os": "Linux 64bit", "$browser": "aiohttp 3.6.2", "$device": "hikari 2.0.0"}, "shard": [0, 2], "intents": 0, "presence": {"since": null, "afk": false, "game": null, "status": "online"}}}
```
