### PR TITLE
Fixed several bugs in shard/bot run logic.

### DIFF
--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -37,6 +37,7 @@ __all__: typing.Final[typing.List[str]] = [
     "ClientHTTPResponseError",
     "InternalServerError",
     "ShardCloseCode",
+    "GatewayConnectionError",
     "GatewayServerClosedConnectionError",
     "GatewayError",
     "MissingIntentWarning",
@@ -136,6 +137,11 @@ class ShardCloseCode(enum.IntEnum):
     INVALID_VERSION = 4012
     INVALID_INTENT = 4013
     DISALLOWED_INTENT = 4014
+
+
+@attr.s(auto_exc=True, slots=True, repr=False, weakref_slot=False)
+class GatewayConnectionError(GatewayError):
+    """An exception thrown if a connection issue occurs."""
 
 
 @attr.s(auto_exc=True, slots=True, repr=False, weakref_slot=False)

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -84,8 +84,6 @@ _BACKOFF_WINDOW: typing.Final[float] = 30.0
 _BACKOFF_BASE: typing.Final[float] = 1.85
 _BACKOFF_INCREMENT_START: typing.Final[int] = 2
 _BACKOFF_CAP: typing.Final[float] = 600.0
-# Ping-pong. Might disable this eventually.
-_PING_PONG_HEARTBEAT_LATENCY: typing.Optional[float] = 20.0
 # Discord seems to invalidate sessions if I send a 1xxx, which is useless
 # for invalid session and reconnect messages where I want to be able to
 # resume.

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -750,7 +750,7 @@ class GatewayShardImpl(shard.GatewayShard):
                         self._logger.debug("shard has shut down")
 
                 except errors.GatewayConnectionError as ex:
-                    self._logger.error("failed to connect to server, reason was %s, will retry shortly", ex.__cause__)
+                    self._logger.error("failed to connect to server, reason was: %s. Will retry shortly", ex.__cause__)
 
                 except errors.GatewayServerClosedConnectionError as ex:
                     if not ex.can_reconnect:

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -874,7 +874,7 @@ class GatewayShardImpl(shard.GatewayShard):
                     if await heartbeat_task:
                         now = date.monotonic()
                         self._logger.error(
-                            "connection is a zombie, last heartbeat sent %ss ago",
+                            "connection is a zombie, last heartbeat sent %.2fs ago",
                             now - self._last_heartbeat_sent,
                         )
                         self._logger.debug("will attempt to reconnect (_run_once => reconnect)")

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -317,7 +317,6 @@ class Test_V6GatewayTransport:
             ws_response_class=shard._V6GatewayTransport,
         )
         mock_client_session.ws_connect.assert_called_once_with(
-            heartbeat=shard._PING_PONG_HEARTBEAT_LATENCY,
             max_msg_size=0,
             proxy=proxy_settings.url,
             proxy_headers=proxy_settings.headers,


### PR DESCRIPTION
- Fixed bug where shard would not immediately close if awaiting startup in bot.
- Fixed bug where shards get requested to shutdown, but never joined, so the
    event loop task reaper is what kills them.
- Removed unused and undocumented shard version parameter.
- Fixed bug in 5 second shard start backoff where close waiter was being waited
    for, but within an `all_of`, which meant it would not do anything until
    any shard threw an exception, or the 5 second window was up.
- Fixed bug where a single shard being closed on startup may be missed if the
    shard is closed directly.
- Added more contextual debug logging to say what case caused the closure each time.

@davfsa, @FasterSpeeding please verify when you get time.