### PR TITLE
Task/debug is dead

### DIFF
--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -218,6 +218,7 @@ from hikari.impl import rate_limits
 from hikari.utilities import aio
 from hikari.utilities import date
 from hikari.utilities import routes
+from hikari.utilities import ux
 
 if typing.TYPE_CHECKING:
     import types
@@ -427,12 +428,12 @@ class RESTBucketManager:
         """
         # Prevent filling memory increasingly until we run out by removing dead buckets every 20s
         # Allocations are somewhat cheap if we only do them every so-many seconds, after all.
-        _LOGGER.debug("rate limit garbage collector started")
+        _LOGGER.log(ux.TRACE, "rate limit garbage collector started")
         while not self.closed_event.is_set():
             try:
                 await asyncio.wait_for(self.closed_event.wait(), timeout=poll_period)
             except asyncio.TimeoutError:
-                _LOGGER.debug("performing rate limit garbage collection pass")
+                _LOGGER.log(ux.TRACE, "performing rate limit garbage collection pass")
                 self.do_gc_pass(expire_after)
         self.gc_task = None
 
@@ -489,7 +490,7 @@ class RESTBucketManager:
             self.real_hashes_to_buckets[full_hash].close()
             del self.real_hashes_to_buckets[full_hash]
 
-        _LOGGER.debug("purged %s stale buckets, %s remain in survival, %s active", dead, survival, active)
+        _LOGGER.log(ux.TRACE, "purged %s stale buckets, %s remain in survival, %s active", dead, survival, active)
 
     def acquire(self, compiled_route: routes.CompiledRoute) -> asyncio.Future[None]:
         """Acquire a bucket for the given _route.

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -40,6 +40,7 @@ from hikari.utilities import aio
 from hikari.utilities import data_binding
 from hikari.utilities import event_stream
 from hikari.utilities import reflect
+from hikari.utilities import ux
 
 if typing.TYPE_CHECKING:
     from hikari.api import shard as gateway_shard
@@ -166,7 +167,8 @@ class EventManagerBase(event_dispatcher.EventDispatcher):
         callback: event_dispatcher.CallbackT[event_dispatcher.EventT_co],
     ) -> None:
         if event_type in self._listeners:
-            _LOGGER.debug(
+            _LOGGER.log(
+                ux.TRACE,
                 "unsubscribing callback %s%s from event-type %s.%s",
                 getattr(callback, "__name__", "<anon>"),
                 inspect.signature(callback),

--- a/hikari/utilities/attr_extensions.py
+++ b/hikari/utilities/attr_extensions.py
@@ -36,6 +36,8 @@ import typing
 
 import attr
 
+from hikari.utilities import ux
+
 ModelT = typing.TypeVar("ModelT")
 SKIP_DEEP_COPY: typing.Final[str] = "skip_deep_copy"
 
@@ -43,7 +45,7 @@ _DEEP_COPIERS: typing.MutableMapping[
     typing.Any, typing.Callable[[typing.Any, typing.MutableMapping[int, typing.Any]], None]
 ] = {}
 _SHALLOW_COPIERS: typing.MutableMapping[typing.Any, typing.Callable[[typing.Any], typing.Any]] = {}
-_LOGGER = logging.getLogger("hikari")
+_LOGGER = logging.getLogger("hikari.models")
 
 
 def invalidate_shallow_copy_cache() -> None:
@@ -107,7 +109,7 @@ def generate_shallow_copier(cls: typing.Type[ModelT]) -> typing.Callable[[ModelT
     setters = ";".join(f"r.{attribute.name}=m.{attribute.name}" for attribute in setters) + ";" if setters else ""
     code = f"def copy(m):r=cls({kwargs});{setters}return r"
     globals_ = {"cls": cls}
-    _LOGGER.debug("generating shallow copy function for %r: %r", cls, code)
+    _LOGGER.log(ux.TRACE, "generating shallow copy function for %r: %r", cls, code)
     exec(code, globals_)  # noqa: S102 - Use of exec detected.
     return typing.cast("typing.Callable[[ModelT], ModelT]", globals_["copy"])
 

--- a/hikari/utilities/ux.py
+++ b/hikari/utilities/ux.py
@@ -40,6 +40,16 @@ import colorlog  # type: ignore[import]
 
 from hikari import _about as about
 
+# While this is discouraged for most purposes in libraries, this enables us to
+# filter out the vast majority of clutter that most network logger calls
+# create. This also has a very minute performance improvement for trace logging
+# calls, as we have to use `logger.log` directly to utilise this properly.
+# We append `_HIKARI` to the name to keep it unique from any other logging
+# levels that may be in use.
+
+TRACE: typing.Final[int] = logging.DEBUG - 5
+logging.addLevelName(TRACE, "TRACE_HIKARI")
+
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.ux")
 
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -105,7 +105,7 @@ class TestRestProvider:
 
     @pytest.fixture()
     def rest_provider(self, rest_client):
-        return rest._RESTProvider(lambda: rest_client)
+        return rest._RESTProvider(lambda: mock.Mock(), None, lambda: mock.Mock(), lambda: rest_client)
 
     def test_rest_property(self, rest_provider, rest_client):
         assert rest_provider.rest == rest_client
@@ -127,7 +127,6 @@ def rest_app():
     return hikari_test_helpers.unslot_class(rest.RESTApp)(
         connector_factory=mock.Mock(),
         connector_owner=False,
-        debug=True,
         executor=None,
         http_settings=mock.Mock(spec_set=config.HTTPSettings),
         proxy_settings=mock.Mock(spec_set=config.ProxySettings),
@@ -137,10 +136,6 @@ def rest_app():
 
 
 class TestRESTApp:
-    def test_debug_property(self, rest_app):
-        rest_app._debug = True
-        assert rest_app.is_debug_enabled is True
-
     def test_executor_property(self, rest_app):
         mock_executor = object()
         rest_app._executor = mock_executor
@@ -172,7 +167,6 @@ class TestRESTApp:
         mock_client.assert_called_once_with(
             connector_factory=rest_app._connector_factory,
             connector_owner=rest_app._connector_owner,
-            debug=rest_app._debug,
             entity_factory=mock_entity_factory,
             executor=rest_app._executor,
             http_settings=rest_app._http_settings,
@@ -230,7 +224,6 @@ def rest_client(rest_client_class):
     obj = rest_client_class(
         connector_factory=mock.Mock(),
         connector_owner=False,
-        debug=True,
         http_settings=mock.Mock(spec=config.HTTPSettings),
         proxy_settings=mock.Mock(spec=config.ProxySettings),
         token="some_token",
@@ -296,7 +289,6 @@ class TestRESTClientImpl:
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
-            debug=True,
             http_settings=mock.Mock(),
             proxy_settings=mock.Mock(),
             token=None,
@@ -311,7 +303,6 @@ class TestRESTClientImpl:
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
-            debug=True,
             http_settings=mock.Mock(),
             proxy_settings=mock.Mock(),
             token="some_token",
@@ -326,7 +317,6 @@ class TestRESTClientImpl:
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
-            debug=True,
             http_settings=mock.Mock(),
             proxy_settings=mock.Mock(),
             token="some_token",
@@ -341,7 +331,6 @@ class TestRESTClientImpl:
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
-            debug=True,
             http_settings=mock.Mock(),
             proxy_settings=mock.Mock(),
             token=None,
@@ -356,7 +345,6 @@ class TestRESTClientImpl:
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
-            debug=True,
             http_settings=mock.Mock(),
             proxy_settings=mock.Mock(),
             token=None,


### PR DESCRIPTION
This must not be merged until #154 is merged, as it builds on top of what was done there.

Essentially, `Bot(debug=True)` no longer exists, and a new TRACE_HIKARI logging level can be used instead.

Fixed some REST-only bug too.