### PR TITLE
Add syntatic sugar to `async with` classes

### DIFF
--- a/hikari/files.py
+++ b/hikari/files.py
@@ -378,6 +378,14 @@ class AsyncReaderContextManager(abc.ABC, typing.Generic[ReaderImplT]):
     ) -> None:
         ...
 
+    def __enter__(self) -> typing.NoReturn:
+        # This is async only.
+        cls = type(self)
+        raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
+
+    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+        return None
+
 
 @attr.s(slots=True, weakref_slot=False)
 @typing.final

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -329,6 +329,14 @@ class RESTApp(traits.ExecutorAware):
     ) -> None:
         await self.close()
 
+    def __enter__(self) -> typing.NoReturn:
+        # This is async only.
+        cls = type(self)
+        raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
+
+    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+        return None
+
 
 class RESTClientImpl(rest_api.RESTClient):
     """Implementation of the V6 and V7-compatible Discord HTTP API.
@@ -465,6 +473,14 @@ class RESTClientImpl(rest_api.RESTClient):
         exc_tb: typing.Optional[types.TracebackType],
     ) -> None:
         await self.close()
+
+    def __enter__(self) -> typing.NoReturn:
+        # This is async only.
+        cls = type(self)
+        raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
+
+    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+        return None
 
     @typing.final
     def _acquire_client_session(self) -> aiohttp.ClientSession:

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -108,6 +108,14 @@ class TypingIndicator(special_endpoints.TypingIndicator):
         if self._task is not None:
             self._task.cancel()
 
+    def __enter__(self) -> typing.NoReturn:
+        # This is async only.
+        cls = type(self)
+        raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
+
+    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+        return None
+
     async def _keep_typing(self) -> None:
         # Cancelled error will occur when the context manager is requested to
         # stop.

--- a/hikari/utilities/event_stream.py
+++ b/hikari/utilities/event_stream.py
@@ -51,7 +51,6 @@ class Streamer(iterators.LazyIterator[EventT], abc.ABC):
 
     Examples
     --------
-
     A streamer may either be started and closed using `async with` syntax
     where `Streamer.open` and `Streamer.close` are implicitly called based on
     context.

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -182,6 +182,17 @@ class TestRESTApp:
             with pytest.raises(RuntimeError):
                 rest_app.acquire(token="token", token_type="Type")
 
+    def test___enter__(self, rest_app):
+        # flake8 gets annoyed if we use "with" here so here's a hacky alternative
+        with pytest.raises(TypeError, match=" is async-only, did you mean 'async with'?"):
+            rest_app.__enter__()
+
+    def test___exit__(self, rest_app):
+        try:
+            rest_app.__exit__(None, None, None)
+        except AttributeError as exc:
+            pytest.fail(exc)
+
 
 @pytest.mark.asyncio
 class TestRESTAppAsync:
@@ -354,6 +365,17 @@ class TestRESTClientImpl:
             entity_factory=None,
         )
         assert obj._rest_url == "https://some.where/api/v2"
+
+    def test___enter__(self, rest_app):
+        # flake8 gets annoyed if we use "with" here so here's a hacky alternative
+        with pytest.raises(TypeError, match=" is async-only, did you mean 'async with'?"):
+            rest_app.__enter__()
+
+    def test___exit__(self, rest_app):
+        try:
+            rest_app.__exit__(None, None, None)
+        except AttributeError as exc:
+            pytest.fail(exc)
 
     def test_http_settings_property(self, rest_client):
         mock_http_settings = object()

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from hikari.impl import special_endpoints
+from tests.hikari import hikari_test_helpers
+
+
+class TestTypingIndicator:
+    @pytest.fixture()
+    def typing_indicator(self):
+        return hikari_test_helpers.mock_class_namespace(special_endpoints.TypingIndicator, init=False)
+
+    def test___enter__(self, typing_indicator):
+        # flake8 gets annoyed if we use "with" here so here's a hacky alternative
+        with pytest.raises(TypeError, match=" is async-only, did you mean 'async with'?"):
+            typing_indicator().__enter__()
+
+    def test___exit__(self, typing_indicator):
+        try:
+            typing_indicator().__exit__(None, None, None)
+        except AttributeError as exc:
+            pytest.fail(exc)

--- a/tests/hikari/test_files.py
+++ b/tests/hikari/test_files.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from hikari import files
+from tests.hikari import hikari_test_helpers
+
+
+class TestAsyncReaderContextManager:
+    @pytest.fixture()
+    def reader(self):
+        return hikari_test_helpers.mock_class_namespace(files.AsyncReaderContextManager)
+
+    def test___enter__(self, reader):
+        # flake8 gets annoyed if we use "with" here so here's a hacky alternative
+        with pytest.raises(TypeError, match=" is async-only, did you mean 'async with'?"):
+            reader().__enter__()
+
+    def test___exit__(self, reader):
+        try:
+            reader().__exit__(None, None, None)
+        except AttributeError as exc:
+            pytest.fail(exc)

--- a/tests/hikari/utilities/test_event_stream.py
+++ b/tests/hikari/utilities/test_event_stream.py
@@ -49,12 +49,12 @@ class TestStreamer:
 
     def test___enter__(self, stub_streamer):
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=" is async-only, did you mean 'async with'?"):
             stub_streamer().__enter__()
 
     def test___exit__(self, stub_streamer):
         try:
-            stub_streamer().__exit__(object(), object(), object())
+            stub_streamer().__exit__(None, None, None)
         except AttributeError as exc:
             pytest.fail(exc)
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
