### PR TITLE
Implemented `user` member on typing events.

### DIFF
--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -141,9 +141,8 @@ class EventFactoryImpl(event_factory.EventFactory):
                 shard=shard,
                 channel_id=channel_id,
                 guild_id=guild_id,
-                user_id=user_id,
                 timestamp=timestamp,
-                member=member,
+                user=member,
             )
 
         return typing_events.PrivateTypingEvent(


### PR DESCRIPTION
- GuildTypingEvent has had the `member` attribute renamed to `user`
    (this is a breaking change).
- PrivateTypingEvent now has a property to get the cached user
    (if possible).
