### PR TITLE
Added documentation about how to use Python's dictConfig incrementally.

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -179,6 +179,37 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
         If a `typing.Dict[str, typing.Any]` equivalent, then this value is
         passed to `logging.config.dictConfig` to allow the user to provide a
         specialized logging configuration of their choice.
+
+        As a side note, you can always opt to leave this on the default value
+        and then use an incremental `logging.config.dictConfig` that applies
+        any additional changes on top of the base configuration, if you prefer.
+        An example of this is as follows:
+
+        ```py
+        import os
+
+        from logging.config import dictConfig
+        from hikari import Bot, Intents
+
+        bot = Bot(token=os.environ["BOT_TOKEN"], intents=Intents.ALL, logs="INFO")
+
+        # We want to make gateway logs output as DEBUG, and TRACE for all ratelimit content.
+        dictConfig({
+            "version": 1,
+            "incremental": True,
+            "loggers": {
+                "hikari.gateway": {
+                    "level": "DEBUG"
+                },
+                "hikari.ratelimits": {
+                    "level": "TRACE_HIKARI"
+                },
+            },
+        })
+        ```
+
+        Taking note that `"TRACE_HIKARI"` is a library-specific logging level
+        which is expected to be more verbose than `"DEBUG"`.
     proxy_settings : typing.Optional[config.ProxySettings]
         If specified, custom proxy settings to use with network-layer logic
         in your application to get through an HTTP-proxy.


### PR DESCRIPTION
This allows users to incrementally build upon what the base logging
config provides, should they wish to use custom levels for anything.

For example:
```py
import os
from logging.config import dictConfig
from hikari import Bot, Intents

bot = Bot(token=os.environ["BOT_TOKEN"], intents=Intents.ALL, logs="INFO")

# We want to make gateway logs output as DEBUG, and TRACE for all ratelimit content.
dictConfig({
    "version": 1,
    "incremental": True,
    "loggers": {
        "hikari.gateway": {
            "level": "DEBUG"
        },
        "hikari.ratelimits": {
            "level": "TRACE_HIKARI"
        },
    },
})
```
...which results in output resembling...
```
D 2020-09-12 16:49:29,206 hikari.ratelimits: GET /gateway/bot is being mapped to new bucket UNKNOWN;-
T 2020-09-12 16:49:29,208 hikari.ratelimits: rate limit garbage collector started
D 2020-09-12 16:49:29,402 hikari.ratelimits: remapping GET /gateway/bot with bucket 41f9cd5d28af77da04563bcb1d67fdfd;- [reset-after:5.332s, limit:2, remaining:1]
I 2020-09-12 16:49:29,402 hikari: planning to start 1 session... you can start 982 sessions before the next window starts at 2020-09-12 18:11:10.535855+01:00
D 2020-09-12 16:49:29,562 hikari.gateway.0: identifying with new session
D 2020-09-12 16:49:29,565 hikari.gateway.0: starting heartbeat with interval 41.25s
I 2020-09-12 16:49:29,772 hikari.gateway.0: shard is ready [session:28419a60f3b49e97385c06668ba94809, user_id:572144340277919754, tag:hikari#5863]
D 2020-09-12 16:49:29,909 hikari.gateway.0: requesting guild members for guild 265828729970753537
T 2020-09-12 16:49:49,208 hikari.ratelimits: performing rate limit garbage collection pass
D 2020-09-12 16:49:49,208 hikari.ratelimits: UNKNOWN;- rate limiter closed
D 2020-09-12 16:49:49,209 hikari.ratelimits: 41f9cd5d28af77da04563bcb1d67fdfd;- rate limiter closed
T 2020-09-12 16:49:49,209 hikari.ratelimits: purged 2 stale buckets, 0 remain in survival, 0 active
T 2020-09-12 16:50:09,210 hikari.ratelimits: performing rate limit garbage collection pass
T 2020-09-12 16:50:09,210 hikari.ratelimits: purged 0 stale buckets, 0 remain in survival, 0 active
T 2020-09-12 16:50:29,212 hikari.ratelimits: performing rate limit garbage collection pass
T 2020-09-12 16:50:29,212 hikari.ratelimits: purged 0 stale buckets, 0 remain in survival, 0 active
T 2020-09-12 16:50:49,215 hikari.ratelimits: performing rate limit garbage collection pass
```