### PR TITLE
Made flag enums lazily load, speeding up cache and event ops.

### DIFF
--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -255,19 +255,32 @@ class PermissionOverwrite(snowflakes.Unique):
     type: PermissionOverwriteType = attr.ib(converter=PermissionOverwriteType, eq=True, hash=True, repr=True)
     """The type of entity this overwrite targets."""
 
-    allow: permissions.Permissions = attr.ib(
-        converter=permissions.Permissions,
-        default=permissions.Permissions.NONE,
-        eq=False,
-        hash=False,
-        repr=False,
-    )
-    """The permissions this overwrite allows."""
+    # Flags are lazily loaded, due to the IntFlag mechanism being overly slow
+    # to execute.
+    _allow: int = attr.ib(default=0, eq=False, hash=False, repr=False)
+    _deny: int = attr.ib(default=0, eq=False, hash=False, repr=False)
 
-    deny: permissions.Permissions = attr.ib(
-        converter=permissions.Permissions, default=permissions.Permissions.NONE, eq=False, hash=False, repr=False
-    )
-    """The permissions this overwrite denies."""
+    @property
+    def allow(self) -> permissions.Permissions:
+        """Return the permissions this overwrite allows.
+
+        Returns
+        -------
+        hikari.permissions.Permissions
+            Permissions explicitly allowed by this overwrite.
+        """
+        return permissions.Permissions(self._allow)
+
+    @property
+    def deny(self) -> permissions.Permissions:
+        """Return the permissions this overwrite denies.
+
+        Returns
+        -------
+        hikari.permissions.Permissions
+            Permissions explicitly denied by this overwrite.
+        """
+        return permissions.Permissions(self._deny)
 
     @property
     def unset(self) -> permissions.Permissions:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -802,9 +802,6 @@ class Guild(PartialGuild, abc.ABC):
     AFK and are moved to the AFK channel (`Guild.afk_channel_id`).
     """
 
-    verification_level: GuildVerificationLevel = attr.ib(eq=False, hash=False, repr=False)
-    """The verification level required for a user to participate in this guild."""
-
     default_message_notifications: GuildMessageNotificationsLevel = attr.ib(eq=False, hash=False, repr=False)
     """The default setting for message notifications in this guild."""
 
@@ -838,9 +835,6 @@ class Guild(PartialGuild, abc.ABC):
 
     Welcome messages and Nitro boost messages may be sent to this channel.
     """
-
-    system_channel_flags: GuildSystemChannelFlag = attr.ib(eq=False, hash=False, repr=False)
-    """Flags for the guild system channel to describe which notifications are suppressed."""
 
     rules_channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib(eq=False, hash=False, repr=False)
     """The ID of the channel where guilds with the `GuildFeature.PUBLIC`
@@ -899,6 +893,38 @@ class Guild(PartialGuild, abc.ABC):
     This is only present if `GuildFeature.PUBLIC` is in `Guild.features` for
     this guild. For all other purposes, it should be considered to be `builtins.None`.
     """
+
+    # Flags are lazily loaded, due to the IntFlag mechanism being overly slow
+    # to execute.
+    _verification_level: int = attr.ib(eq=False, hash=False, repr=False)
+    _system_channel_flags: int = attr.ib(eq=False, hash=False, repr=False)
+
+    @property
+    def verification_level(self) -> GuildVerificationLevel:
+        """Return the verification level required for this guild.
+
+        This defines the verification level needed for a user to participate in
+        this guild.
+
+        Returns
+        -------
+        GuildVerificationLevel
+            The verification level required for this guild.
+        """
+        return GuildVerificationLevel(self._verification_level)
+
+    @property
+    def system_channel_flags(self) -> GuildSystemChannelFlag:
+        """Return flags for the guild system channel.
+
+        These are used to describe which notifications are suppressed.
+
+        Returns
+        -------
+        GuildSystemChannelFlag
+            The system channel flags for this channel.
+        """
+        return GuildSystemChannelFlag(self._system_channel_flags)
 
     @property
     @abc.abstractmethod

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -121,7 +121,7 @@ class _GuildFields(_PartialGuildFields):
     widget_channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
     system_channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
     is_widget_enabled: typing.Optional[bool] = attr.ib()
-    system_channel_flags: guild_models.GuildSystemChannelFlag = attr.ib()
+    system_channel_flags: int = attr.ib()
     rules_channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
     max_video_channel_users: typing.Optional[int] = attr.ib()
     vanity_url_code: typing.Optional[str] = attr.ib()
@@ -191,8 +191,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             audit_log_models.AuditLogChangeKey.APPLICATION_ID: snowflakes.Snowflake,
             audit_log_models.AuditLogChangeKey.PERMISSIONS: permission_models.Permissions,
             audit_log_models.AuditLogChangeKey.COLOR: color_models.Color,
-            audit_log_models.AuditLogChangeKey.ALLOW: permission_models.Permissions,
-            audit_log_models.AuditLogChangeKey.DENY: permission_models.Permissions,
+            audit_log_models.AuditLogChangeKey.ALLOW: int,
+            audit_log_models.AuditLogChangeKey.DENY: int,
             audit_log_models.AuditLogChangeKey.CHANNEL_ID: snowflakes.Snowflake,
             audit_log_models.AuditLogChangeKey.INVITER_ID: snowflakes.Snowflake,
             audit_log_models.AuditLogChangeKey.MAX_USES: _deserialize_max_uses,
@@ -1771,9 +1771,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     def deserialize_user(self, payload: data_binding.JSONObject) -> user_models.User:
         user_fields = self._set_user_attributes(payload)
-        flags = (
-            user_models.UserFlag(payload["public_flags"]) if "public_flags" in payload else user_models.UserFlag.NONE
-        )
         return user_models.UserImpl(
             app=self._app,
             id=user_fields.id,
@@ -1782,7 +1779,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             avatar_hash=user_fields.avatar_hash,
             is_bot=user_fields.is_bot,
             is_system=user_fields.is_system,
-            flags=flags,
+            flags=int(payload.get("public_flags", 0)),
         )
 
     def deserialize_my_user(self, payload: data_binding.JSONObject) -> user_models.OwnUser:

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -318,9 +318,9 @@ class EventFactoryImpl(event_factory.EventFactory):
         if len(user_payload) > 1:
             # PartialUser
             discriminator = user_payload["discriminator"] if "discriminator" in user_payload else undefined.UNDEFINED
-            flags: undefined.UndefinedOr[user_models.UserFlag] = undefined.UNDEFINED
+            flags: undefined.UndefinedOr[int] = undefined.UNDEFINED
             if "public_flags" in user_payload:
-                flags = user_models.UserFlag(user_payload["public_flags"])
+                flags = int(user_payload["public_flags"])
 
             user = user_models.PartialUserImpl(
                 app=self._app,

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -343,14 +343,30 @@ class PartialMessage(snowflakes.Unique):
     message_reference: undefined.UndefinedNoneOr[MessageCrosspost] = attr.ib(repr=False)
     """The message's cross-posted reference data."""
 
-    flags: undefined.UndefinedNoneOr[MessageFlag] = attr.ib(repr=False)
-    """The message's flags."""
-
     nonce: undefined.UndefinedNoneOr[str] = attr.ib(repr=False)
     """The message nonce.
 
     This is a string used for validating a message was sent.
     """
+
+    # Flags are lazily loaded, due to the IntFlag mechanism being overly slow
+    # to execute.
+    _flags: undefined.UndefinedNoneOr[int] = attr.ib(repr=False)
+
+    @property
+    def flags(self) -> undefined.UndefinedNoneOr[MessageFlag]:
+        """Return flags for thge message if known.
+
+        If no flags are set, this returns `builtins.None`.
+
+        If unknown, this returns `hikari.undefined.UNDEFINED`
+
+        Returns
+        -------
+        hikari.undefined.UndefinedNoneOr[MessageFlag]
+            The message flags, if known and set.
+        """
+        return MessageFlag(self._flags) if isinstance(self._flags, int) else self._flags
 
     @property
     def link(self) -> str:
@@ -879,8 +895,9 @@ class Message(PartialMessage):
     message_reference: typing.Optional[MessageCrosspost]
     """The message crossposted reference data."""
 
-    flags: typing.Optional[MessageFlag]
-    """The message flags."""
-
     nonce: typing.Optional[str]
     """The message nonce. This is a string used for validating a message was sent."""
+
+    _flags = typing.Optional[int]
+    flags: typing.Optional[MessageFlag]
+    """The message flags."""

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -231,8 +231,20 @@ class RichActivity(Activity):
     is_instance: typing.Optional[bool] = attr.ib(repr=False)
     """Whether this activity is an instanced game session."""
 
-    flags: typing.Optional[ActivityFlag] = attr.ib(repr=False)
-    """Flags that describe what the activity includes, if present."""
+    # Flags are lazily loaded, due to the IntFlag mechanism being overly slow
+    # to execute.
+    _flags: typing.Optional[int] = attr.ib(repr=False)
+
+    @property
+    def flags(self) -> typing.Optional[ActivityFlag]:
+        """Return flags describing the activity type.
+
+        Returns
+        -------
+        typing.Optional[ActivityFlag]
+            Flags, if present, otherwise `builtins.None`.
+        """
+        return ActivityFlag(self._flags) if self._flags is not None else None
 
 
 @typing.final

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -332,8 +332,12 @@ class PartialUserImpl(PartialUser):
     is_system: undefined.UndefinedOr[bool] = attr.ib(eq=False, hash=False, repr=False)
     """Whether this user is a system account."""
 
-    flags: undefined.UndefinedOr[UserFlag] = attr.ib(eq=False, hash=False)
-    """Public flags for this user."""
+    _flags: undefined.UndefinedOr[int] = attr.ib(eq=False, hash=False)
+
+    @property
+    def flags(self) -> undefined.UndefinedOr[UserFlag]:
+        """Public flags for this user."""
+        return UserFlag(self._flags) if self._flags is not undefined.UNDEFINED else undefined.UNDEFINED
 
     @property
     def mention(self) -> str:
@@ -398,6 +402,7 @@ class UserImpl(PartialUserImpl, User):
     is_system: bool
     """`builtins.True` if this user is a system account, `builtins.False` otherwise."""
 
+    _flags: int
     flags: UserFlag
     """The public flags for this user."""
 

--- a/hikari/utilities/cache.py
+++ b/hikari/utilities/cache.py
@@ -578,7 +578,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
     assets: typing.Optional[presences.ActivityAssets] = attr.ib()
     secrets: typing.Optional[presences.ActivitySecret] = attr.ib()
     is_instance: typing.Optional[bool] = attr.ib()
-    flags: typing.Optional[presences.ActivityFlag] = attr.ib()
+    flags: typing.Optional[int] = attr.ib()
 
     @classmethod
     def build_from_entity(cls: typing.Type[RichActivityData], entity: presences.RichActivity) -> RichActivityData:

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -122,8 +122,8 @@ def test_GroupDMChannel_str_operator_when_name_is_None():
 
 def test_PermissionOverwrite_unset():
     overwrite = channels.PermissionOverwrite(type=channels.PermissionOverwriteType.MEMBER, id=1234321)
-    overwrite.allow = permissions.Permissions.CREATE_INSTANT_INVITE
-    overwrite.deny = permissions.Permissions.CHANGE_NICKNAME
+    overwrite._allow = permissions.Permissions.CREATE_INSTANT_INVITE
+    overwrite._deny = permissions.Permissions.CHANGE_NICKNAME
     assert overwrite.unset == permissions.Permissions(-67108866)
 
 


### PR DESCRIPTION
IntFlags are now stored on models in private fields as raw ints.

These are cast to the flag type only when accessed, which speeds up startup by some time.