### PR TITLE
Add Competing activity type

### DIFF
--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -85,6 +85,9 @@ class ActivityType(enum.IntEnum):
         Bots currently do not support setting custom statuses.
     """
 
+    COMPETING = 5
+    """Shows up as `Competing in <name>`"""
+
     def __str__(self) -> str:
         return self.name
 


### PR DESCRIPTION
For some reason discord hasn't documented the fields this introduces to the activity object so this may end up being a preliminary commit.

### Summary
Add "Competing" activity type

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
