### PR TITLE
Added new logic to shard that should hopefully detect random socket c…

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -315,7 +315,7 @@ class _V6GatewayTransport(aiohttp.ClientWebSocketResponse):
             # Windows will sometimes raise an aiohttp.ClientOSError
             # If we cannot do DNS lookup, this will fail with a ClientConnectionError
             # usually.
-            raise errors.GatewayConnectionError(f"Failed to connect to gateway {type(ex).__name__}: {ex}")
+            raise errors.GatewayConnectionError(f"Failed to connect to gateway {type(ex).__name__}: {ex}") from ex
 
         finally:
             await exit_stack.aclose()

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -315,7 +315,7 @@ class _V6GatewayTransport(aiohttp.ClientWebSocketResponse):
             # Windows will sometimes raise an aiohttp.ClientOSError
             # If we cannot do DNS lookup, this will fail with a ClientConnectionError
             # usually.
-            raise errors.GatewayError(f"Failed to connect to gateway {type(ex).__name__}: {ex}")
+            raise errors.GatewayConnectionError(f"Failed to connect to gateway {type(ex).__name__}: {ex}")
 
         finally:
             await exit_stack.aclose()

--- a/tests/hikari/impl/test_rate_limits.py
+++ b/tests/hikari/impl/test_rate_limits.py
@@ -450,8 +450,7 @@ class TestExponentialBackOff:
             base=5, maximum=sys.float_info.max, jitter_multiplier=0.0, initial_increment=power
         )
 
-        with pytest.raises(asyncio.TimeoutError):
-            next(eb)
+        assert next(eb) == sys.float_info.max
 
     def test_increment_maximum(self):
         max_bound = 64
@@ -460,16 +459,14 @@ class TestExponentialBackOff:
         for _ in range(iterations):
             next(eb)
 
-        with pytest.raises(asyncio.TimeoutError):
-            next(eb)
+        assert next(eb) == max_bound
 
     def test_increment_does_not_increment_when_on_maximum(self):
-        eb = rate_limits.ExponentialBackOff(2, 32, initial_increment=5)
+        eb = rate_limits.ExponentialBackOff(2, 32, initial_increment=5, jitter_multiplier=0)
 
         assert eb.increment == 5
 
-        with pytest.raises(asyncio.TimeoutError):
-            next(eb)
+        assert next(eb) == 32
 
         assert eb.increment == 5
 


### PR DESCRIPTION
…losures.

It appears Windows will send an EOF to the TCP socket if an adapter closes.
This seems to happen when connecting to a VPN or putting the computer into
hibernation/sleep mode. When this occurs, aiohttp assumes it means a normal
closure and gracefully closes, but we do not usually have a way to determine
this.

We can however see that aiohttp invokes ClientWebSocketResponse#close which
is the same call we make. The solution is to make a facading method that we
invoke that sets a flag determining that we did in fact want to close. If this
doesn't get set, we know aiohttp is the one to blame.

@FasterSpeeding please try and break this.