### PR TITLE
Fixes edge case where messages in guilds had a None 'author' attribute

### DIFF
--- a/hikari/utilities/ux.py
+++ b/hikari/utilities/ux.py
@@ -22,10 +22,6 @@
 """User-experience extensions and utilities."""
 from __future__ import annotations
 
-import time
-
-from hikari.utilities import net
-
 __all__: typing.List[str] = ["init_logging", "print_banner", "supports_color", "HikariVersion", "check_for_updates"]
 
 import contextlib
@@ -37,11 +33,13 @@ import platform
 import re
 import string
 import sys
+import time
 import typing
 
 import colorlog  # type: ignore[import]
 
 from hikari import _about as about
+from hikari.utilities import net
 
 if typing.TYPE_CHECKING:
     from hikari import config


### PR DESCRIPTION
Fixes edge case where messages in guilds had a None 'author' attribute if a webhook sent the message.

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
