### PR TITLE
Fix inconsistecy in cache naming

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -78,8 +78,8 @@ class Cache(abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @abc.abstractmethod
-    def get_dm(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
-        """Get a DM object from the cache.
+    def get_dm_channel(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
+        """Get a DM channel object from the cache.
 
         Parameters
         ----------
@@ -95,8 +95,8 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_dms_view(self) -> CacheView[snowflakes.Snowflake, channels.DMChannel]:
-        """Get a view of the DM objects in the cache.
+    def get_dm_channels_view(self) -> CacheView[snowflakes.Snowflake, channels.DMChannel]:
+        """Get a view of the DM channel objects in the cache.
 
         Returns
         -------

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -452,7 +452,7 @@ class PrivateMessageCreateEvent(PrivateMessageEvent, MessageCreateEvent):
             The DM channel that the message was sent in, if known and cached,
             otherwise, `builtins.None`.
         """
-        return self.app.cache.get_dm(self.author_id)
+        return self.app.cache.get_dm_channel(self.author_id)
 
     @property
     def author(self) -> users.User:
@@ -517,7 +517,7 @@ class PrivateMessageUpdateEvent(PrivateMessageEvent, MessageUpdateEvent):
     @property
     def channel(self) -> typing.Optional[channels.DMChannel]:
         # <<inherited docstring from MessagesEvent>>.
-        return self.app.cache.get_dm(self.author_id)
+        return self.app.cache.get_dm_channel(self.author_id)
 
     @property
     def author(self) -> typing.Optional[users.User]:

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -288,7 +288,7 @@ class PrivateTypingEvent(TypingEvent):
         typing.Optional[hikari.channels.DMChannel]
             The channel, if known.
         """
-        return self.app.cache.get_dm(self.user_id)
+        return self.app.cache.get_dm_channel(self.user_id)
 
     @property
     def user(self) -> typing.Optional[users.User]:

--- a/hikari/impl/stateful_cache.py
+++ b/hikari/impl/stateful_cache.py
@@ -180,13 +180,13 @@ class StatefulCacheImpl(cache.MutableCache):
         self._garbage_collect_user(user_id, decrement=1)
         return channel
 
-    def get_dm(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
+    def get_dm_channel(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
         if user_id in self._dm_entries:
             return self._build_dm(self._dm_entries[user_id])
 
         return None
 
-    def get_dms_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.DMChannel]:
+    def get_dm_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.DMChannel]:
         if not self._dm_entries:
             return cache_utility.EmptyCacheView()
 
@@ -208,9 +208,9 @@ class StatefulCacheImpl(cache.MutableCache):
     def update_dm(
         self, channel: channels.DMChannel, /
     ) -> typing.Tuple[typing.Optional[channels.DMChannel], typing.Optional[channels.DMChannel]]:
-        cached_channel = self.get_dm(channel.recipient.id)
+        cached_channel = self.get_dm_channel(channel.recipient.id)
         self.set_dm(channel)
-        return cached_channel, self.get_dm(channel.recipient.id)
+        return cached_channel, self.get_dm_channel(channel.recipient.id)
 
     def _build_emoji(
         self,

--- a/hikari/impl/stateless_cache.py
+++ b/hikari/impl/stateless_cache.py
@@ -73,10 +73,10 @@ class StatelessCacheImpl(cache.MutableCache):
     def delete_dm(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
         raise self._no_cache()
 
-    def get_dm(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
+    def get_dm_channel(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[channels.DMChannel]:
         return None
 
-    def get_dms_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.DMChannel]:
+    def get_dm_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.DMChannel]:
         return cache_utilities.EmptyCacheView()
 
     def set_dm(self, channel: channels.DMChannel, /) -> None:

--- a/tests/hikari/events/test_typing_events.py
+++ b/tests/hikari/events/test_typing_events.py
@@ -130,10 +130,10 @@ class TestPrivateTypingEvent:
         )
 
     async def test_channel(self, event):
-        event.app.cache.get_dm = mock.Mock(return_value=mock.Mock(spec_set=channels.DMChannel))
+        event.app.cache.get_dm_channel = mock.Mock(return_value=mock.Mock(spec_set=channels.DMChannel))
         result = event.channel
-        assert result is event.app.cache.get_dm.return_value
-        event.app.cache.get_dm.assert_called_once_with(456)
+        assert result is event.app.cache.get_dm_channel.return_value
+        event.app.cache.get_dm_channel.assert_called_once_with(456)
 
     def test_user(self, event):
         event.app.cache.get_user = mock.Mock(return_value=mock.Mock(spec_set=users.User))

--- a/tests/hikari/impl/test_stateful_cache.py
+++ b/tests/hikari/impl/test_stateful_cache.py
@@ -159,7 +159,7 @@ class TestStatefulCacheImpl:
     def test_delete_dm_for_unknown_channel_channel(self, cache_impl):
         assert cache_impl.delete_dm(snowflakes.Snowflake(564234123)) is None
 
-    def test_get_dm_for_known_channel(self, cache_impl):
+    def test_get_dm_channel_for_known_channel(self, cache_impl):
         mock_channel_data = mock.Mock(cache.DMChannelData)
         mock_channel = mock.Mock(channels.DMChannel)
         cache_impl._dm_entries = mapping.DictionaryCollection(
@@ -169,13 +169,13 @@ class TestStatefulCacheImpl:
             }
         )
         cache_impl._build_dm = mock.Mock(return_value=mock_channel)
-        assert cache_impl.get_dm(snowflakes.Snowflake(65234123)) is mock_channel
+        assert cache_impl.get_dm_channel(snowflakes.Snowflake(65234123)) is mock_channel
         cache_impl._build_dm.assert_called_once_with(mock_channel_data)
 
-    def test_get_dm_for_unknown_channel(self, cache_impl):
-        assert cache_impl.get_dm(snowflakes.Snowflake(561243)) is None
+    def test_get_dm_channel_for_unknown_channel(self, cache_impl):
+        assert cache_impl.get_dm_channel(snowflakes.Snowflake(561243)) is None
 
-    def test_get_dm_view(self, cache_impl):
+    def test_get_dm_channel_view(self, cache_impl):
         mock_channel_data_1 = mock.Mock(
             cache.DMChannelData,
         )
@@ -198,7 +198,7 @@ class TestStatefulCacheImpl:
                 snowflakes.Snowflake(65656): mock_channel_data_2,
             }
         )
-        view = cache_impl.get_dms_view()
+        view = cache_impl.get_dm_channels_view()
         assert view == {
             snowflakes.Snowflake(54213): mock_channel_1,
             snowflakes.Snowflake(65656): mock_channel_2,
@@ -222,8 +222,8 @@ class TestStatefulCacheImpl:
             ]
         )
 
-    def test_get_dm_view_when_no_channels_cached(self, cache_impl):
-        assert cache_impl.get_dms_view() == {}
+    def test_get_dm_channel_view_when_no_channels_cached(self, cache_impl):
+        assert cache_impl.get_dm_channels_view() == {}
 
     def test_set_dm(self, cache_impl):
         mock_recipient = mock.Mock(users.User, id=snowflakes.Snowflake(7652341234))
@@ -266,14 +266,14 @@ class TestStatefulCacheImpl:
         mock_old_cached_channel = mock.Mock(channels.DMChannel)
         mock_new_cached_channel = mock.Mock(channels.DMChannel)
         mock_channel = mock.Mock(channels.DMChannel, recipient=mock.Mock(users.User, id=snowflakes.Snowflake(53123123)))
-        cache_impl.get_dm = mock.Mock(side_effect=[mock_old_cached_channel, mock_new_cached_channel])
+        cache_impl.get_dm_channel = mock.Mock(side_effect=[mock_old_cached_channel, mock_new_cached_channel])
         cache_impl.set_dm = mock.Mock()
         assert cache_impl.update_dm(mock_channel) == (
             mock_old_cached_channel,
             mock_new_cached_channel,
         )
         cache_impl.set_dm.assert_called_once_with(mock_channel)
-        cache_impl.get_dm.assert_has_calls([mock.call(53123123), mock.call(53123123)])
+        cache_impl.get_dm_channel.assert_has_calls([mock.call(53123123), mock.call(53123123)])
 
     def test__build_emoji(self, cache_impl):
         emoji_data = cache.KnownCustomEmojiData(

--- a/tests/hikari/impl/test_stateless_cache.py
+++ b/tests/hikari/impl/test_stateless_cache.py
@@ -40,11 +40,11 @@ class TestStatelessCache:
         with pytest.raises(NotImplementedError):
             assert component.delete_dm(123)
 
-    def test_get_dm(self, component):
-        assert component.get_dm(123) is None
+    def test_get_dm_channel(self, component):
+        assert component.get_dm_channel(123) is None
 
-    def test_get_dms_view(self, component):
-        assert component.get_dms_view() == {}
+    def test_get_dm_channels_view(self, component):
+        assert component.get_dm_channels_view() == {}
 
     def test_set_dm(self, component):
         with pytest.raises(NotImplementedError):

--- a/tests/hikari/utilities/test_ux.py
+++ b/tests/hikari/utilities/test_ux.py
@@ -32,8 +32,8 @@ import pytest
 
 from hikari import _about
 from hikari import config
-from hikari.utilities import ux
 from hikari.utilities import net
+from hikari.utilities import ux
 from tests.hikari import hikari_test_helpers
 
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
