### PR TITLE
Task/enum

### DIFF
--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -44,6 +44,7 @@ from hikari import guilds
 from hikari import snowflakes
 from hikari import urls
 from hikari.utilities import attr_extensions
+from hikari.utilities import enums
 from hikari.utilities import routes
 
 if typing.TYPE_CHECKING:
@@ -52,9 +53,8 @@ if typing.TYPE_CHECKING:
     from hikari import users
 
 
-@enum.unique
 @typing.final
-class OAuth2Scope(str, enum.Enum):
+class OAuth2Scope(str, enums.Enum):
     """OAuth2 Scopes that Discord allows.
 
     These are categories of permissions for applications using the OAuth2 API

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -49,7 +49,9 @@ import attr
 
 from hikari import snowflakes
 from hikari.utilities import attr_extensions
+from hikari.utilities import enums
 from hikari.utilities import mapping
+
 
 if typing.TYPE_CHECKING:
     from hikari import channels
@@ -60,7 +62,7 @@ if typing.TYPE_CHECKING:
 
 
 @typing.final
-class AuditLogChangeKey(str, enum.Enum):
+class AuditLogChangeKey(str, enums.Enum):
     """Commonly known and documented keys for audit log change objects.
 
     Others may exist. These should be expected to default to the raw string

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -52,7 +52,6 @@ from hikari.utilities import attr_extensions
 from hikari.utilities import enums
 from hikari.utilities import mapping
 
-
 if typing.TYPE_CHECKING:
     from hikari import channels
     from hikari import guilds

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -54,6 +54,7 @@ from hikari import undefined
 from hikari import urls
 from hikari import users
 from hikari.utilities import attr_extensions
+from hikari.utilities import enums
 from hikari.utilities import routes
 
 if typing.TYPE_CHECKING:
@@ -201,9 +202,8 @@ class ChannelFollow:
         return channel
 
 
-@enum.unique
 @typing.final
-class PermissionOverwriteType(str, enum.Enum):
+class PermissionOverwriteType(str, enums.Enum):
     """The type of entity a Permission Overwrite targets."""
 
     ROLE = "role"

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -59,6 +59,7 @@ from hikari import snowflakes
 from hikari import urls
 from hikari import users
 from hikari.utilities import attr_extensions
+from hikari.utilities import enums
 from hikari.utilities import flag
 from hikari.utilities import routes
 
@@ -94,9 +95,8 @@ class GuildExplicitContentFilterLevel(enum.IntEnum):
         return self.name
 
 
-@enum.unique
 @typing.final
-class GuildFeature(str, enum.Enum):
+class GuildFeature(str, enums.Enum):
     """Features that a guild can provide."""
 
     ANIMATED_ICON = "ANIMATED_ICON"

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -44,6 +44,7 @@ import attr
 
 from hikari import snowflakes
 from hikari.utilities import attr_extensions
+from hikari.utilities import enums
 from hikari.utilities import flag
 
 if typing.TYPE_CHECKING:
@@ -251,7 +252,7 @@ class RichActivity(Activity):
 
 
 @typing.final
-class Status(str, enum.Enum):
+class Status(str, enums.Enum):
     """The status of a member."""
 
     ONLINE = "online"

--- a/hikari/utilities/enums.py
+++ b/hikari/utilities/enums.py
@@ -19,146 +19,159 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Re-implementation of parts of Python's `enum` protocol to be lightweight."""
+"""Implementation of parts of Python's `enum` protocol to be fast."""
 from __future__ import annotations
 
 __all__: typing.List[str] = ["Enum"]
 
-import inspect
 import sys
 import types
 import typing
 
-if typing.TYPE_CHECKING:
-    # Hikari only uses these two types.
-    from enum import Enum
-else:
-    class _EnumNamespace(dict):
-        def __init__(self, base) -> None:
-            super().__init__()
-            self.base = base
-            self.names_to_values = {}
-            self.values_to_names = {}
-            self["__doc__"] = "An enumeration"
-            self.descriptors = {}
+T = typing.TypeVar("T", bound=typing.Hashable)
+E = typing.TypeVar("E", bound="_EnumMeta")
 
-        def __setitem__(self, name: str, value: typing.Any) -> None:
-            name = sys.intern(name)
-            if issubclass(self.base, str):
-                value = sys.intern(value)
-            else:
-                try:
-                    # This will fail if unhashable.
-                    hash(value)
-                except TypeError:
-                    raise TypeError("Cannot have unhashable values in this enum type") from None
 
-            if name.startswith("_"):
-                super().__setitem__(name, value)
-                return
+class _EnumNamespace(dict):
+    def __init__(self, base) -> None:
+        super().__init__()
+        self.base = base
+        self.names_to_values = {}
+        self.values_to_names = {}
+        self["__doc__"] = "An enumeration."
 
-            if name == "" or name == "mro":
-                raise TypeError(f"Invalid enum member name: {name!r}")
+    def __setitem__(self, name: str, value: typing.Any) -> None:
+        if name == "" or name == "mro":
+            raise TypeError(f"Invalid enum member name: {name!r}")
 
-            if hasattr(value, "__get__") or hasattr(value, "__set__") or hasattr(value, "__del__"):
-                super().__setitem__(name, value)
-                return
+        if name.startswith("_"):
+            # Dunder/sunder, so skip.
+            super().__setitem__(name, value)
+            return
 
-            if name in self.names_to_values:
-                raise TypeError("Cannot define same name twice")
-            if name in self.values_to_names:
-                raise TypeError("Cannot define same value twice")
-            if not isinstance(value, self.base):
-                raise TypeError("Enum values must be an instance of the base type of the enum")
+        if hasattr(value, "__get__") or hasattr(value, "__set__") or hasattr(value, "__del__"):
+            super().__setitem__(name, value)
+            return
 
-            self.names_to_values[name] = value
-            self.values_to_names[value] = name
+        if not isinstance(value, self.base):
+            raise TypeError(f"Expected member {name} to be of type {self.base.__name__} but was {type(value).__name__}")
 
-    def _make_delegate(name):
-        return property(lambda self: getattr(self._value_, name))
+        name = sys.intern(name)
 
-    def _make_member_type(enum_type_name, base):
-        cls = type(f"{enum_type_name}Member", (base,), {"__slots__": ("_name_", "_value_")})
+        if issubclass(self.base, str):
+            value = sys.intern(value)
+        else:
+            try:
+                # This will fail if unhashable.
+                hash(value)
+            except TypeError:
+                raise TypeError(f"Cannot have unhashable values in this enum type ({name}: {value!r})") from None
 
-        # Delegate members if possible.
-        for name, value in inspect.getmembers(base):
-            # __dunder_names__
-            if len(name) > 4 and name[:2] == name[-2:] == '__' and name[2] != '_' and name[-3] != '_':
-                continue
-            elif isinstance(value, staticmethod):
-                setattr(cls, name, value)
-            elif isinstance(value, classmethod):
-                setattr(cls, name, classmethod(value.__func__))
-            elif hasattr(value, "__get__") or hasattr(value, "__set__") or hasattr(value, "__delete__"):
-                setattr(cls, name, _make_delegate(name))
-            else:
-                setattr(cls, name, value)
+        if name in self.names_to_values:
+            raise TypeError("Cannot define same name twice")
+        if name in self.values_to_names:
+            raise TypeError("Cannot define same value twice")
+        if not isinstance(value, self.base):
+            raise TypeError("Enum values must be an instance of the base type of the enum")
 
-        cls.name = property(lambda self: self._name_)
-        cls.value = property(lambda self: self._value_)
-        cls.__str__ = lambda self: f"<{enum_type_name}.{self._name_}"
-        cls.__repr__ = lambda self: f"<{enum_type_name}.{self._name_}: {self._value_!r}>"
-        cls.__getattr__ = lambda self, _name: getattr(self._value_, _name)
+        self.names_to_values[name] = value
+        self.values_to_names[value] = name
+
+
+def _make_delegate(name):
+    # Do this in a module-global method to skip filling __closure__ with
+    # contextual shit we don't want from the metaclass. Lets that crap get
+    # garbage collected properly.
+    return property(lambda self: getattr(self._value_, name))
+
+
+# We refer to these from the metaclasses, but obviously this won't work
+# until these classes are created, and since they use the metaclasses as
+# a base metaclass, we have to give these values for _EnumMeta to not
+# flake out when initializing them.
+_Enum = NotImplemented
+
+
+def _make_cast(value2member_map):
+    def __cast__(_: E, value: T):
+        return value2member_map[value]
+
+    return __cast__
+
+
+class _EnumMeta(type):
+    __objtype__: T
+    __enumtype__: E
+    _value2member_map_: typing.Mapping[T, E]
+    _name2member_map_: typing.Mapping[str, E]
+    __members__: types.MappingProxyType[str, T]
+
+    def __init_member__(cls: E):
+        return super().__call__()
+
+    def __call__(cls: E, value: T):
+        return cls._value2member_map_[value]
+
+    @staticmethod
+    def __new__(mcs, name, bases, namespace):
+        global _Enum
+
+        if name == "Enum" and _Enum is NotImplemented:
+            # noinspection PyRedundantParentheses
+            return (_Enum := super().__new__(mcs, name, bases, namespace))
+
+        try:
+            base, enum_type = bases
+        except ValueError:
+            raise TypeError("Expected two base classes for an enum")
+
+        if not issubclass(enum_type, _Enum):
+            raise TypeError("second base type for enum must be derived from Enum")
+
+        new_namespace = {
+            "__objtype__": base,
+            "__enumtype__": enum_type,
+            "_name2member_map_": (name2member := {}),
+            "_value2member_map_": (value2member := {}),
+            "__members__": types.MappingProxyType(namespace.names_to_values),
+            **namespace,
+        }
+
+        cls = super().__new__(mcs, name, bases, new_namespace)
+
+        for name, value in namespace.names_to_values.items():
+            # Patching the member init call is around 100ns faster per call than
+            # using the default type.__call__ which would make us do the lookup
+            # in cls.__new__. Reason for this is that python will also always
+            # invoke cls.__init__ if we do this, so we end up with two function
+            # calls.
+            member = cls.__init_member__()
+            member.name = name
+            member.value = value
+            name2member[name] = member
+            value2member[value] = member
+
         return cls
 
-    # We refer to these from the metaclasses, but obviously this won't work
-    # until these classes are created, and since they use the metaclasses as
-    # a base metaclass, we have to give these values for _EnumMeta to not
-    # flake out when initializing them.
-    _Enum = NotImplemented
-
-    class _EnumMeta(type):
-        def __call__(cls, value):
-            return cls._values_to_names_[value]
-
-        def __init__(cls, name, bases, namespace):
-            super().__init__(name, bases, namespace)
-
-        @staticmethod
-        def __new__(mcs, name, bases, namespace):
-            global _Enum
-
-            if not bases:
-                if name == "Enum" and _Enum is NotImplemented:
-                    return (_Enum := super().__new__(mcs, name, bases, namespace))
-                raise TypeError("Expected two base classes for an enum")
-
+    @classmethod
+    def __prepare__(mcs, name, bases=()):
+        try:
+            # Fails if Enum is not defined. We check this in `__new__` properly.
             base, enum_type = bases
-            new_namespace = {
-                "__objtype__": (member_type := _make_member_type(name, base)),
-                "_name2value_map_": (name2value := namespace.names_to_values),
-                "_name2member_map_": (name2member := {}),
-                "_value2member_map_": (value2member := {}),
-                "__members__": types.MappingProxyType(name2value),
-                **namespace,
-            }
 
-            for name, value in name2value.items():
-                member = member_type(_name_=name, _value_=value)
-                name2member[name] = member
+            if isinstance(base, _EnumMeta):
+                raise TypeError("First base to an enum must be the type to combine with, not _EnumMeta")
+            if not isinstance(enum_type, _EnumMeta):
+                raise TypeError("Second base to an enum must be the enum type (derived from _EnumMeta) to be used")
 
-            return super().__new__(mcs, name, bases, new_namespace)
+            return _EnumNamespace(base)
+        except ValueError:
+            return _EnumNamespace(object)
 
-        @staticmethod
-        def __prepare__(mcs, name, bases=()):
-            try:
-                # Fails if Enum is not defined. We check this in `__new__` properly.
-                base, enum_type = bases
 
-                if isinstance(base, _EnumMeta):
-                    raise TypeError("First base to an enum must be the type to combine with, not _EnumMeta")
-                if not isinstance(enum_type, _EnumMeta):
-                    raise TypeError("Second base to an enum must be the enum type (derived from _EnumMeta) to use")
-
-                return _EnumNamespace(base)
-            except ValueError:
-                return _EnumNamespace(object)
-
-    class Enum(metaclass=_EnumMeta):
-        pass
-
-    class DayOfWeek(str, Enum):
-        MON = "Monday"
-        TUE = "Tuesday"
-
-    print(dir(DayOfWeek), type(DayOfWeek), DayOfWeek.__members__, sep="\n")
+class Enum(metaclass=_EnumMeta):
+    __objtype__: typing.Type[T]
+    __enumtype__: typing.Type[E]
+    _value2member_map_: typing.ClassVar[typing.Mapping[T, E]]
+    _name2member_map_: typing.ClassVar[typing.Mapping[str, E]]
+    __members__: typing.ClassVar[types.MappingProxyType[str, T]]

--- a/hikari/utilities/enums.py
+++ b/hikari/utilities/enums.py
@@ -109,9 +109,6 @@ def _attr_mutator(self, *_):
 
 
 class _EnumMeta(type):
-    def __init_member__(cls):
-        return super().__call__()
-
     def __call__(cls, value):
         return cls._value2member_map_[value]
 
@@ -155,7 +152,7 @@ class _EnumMeta(type):
             # in cls.__new__. Reason for this is that python will also always
             # invoke cls.__init__ if we do this, so we end up with two function
             # calls.
-            member = cls.__init_member__()
+            member = cls.__new__(cls, value)
             member.name = name
             member.value = value
             name2member[name] = member
@@ -188,8 +185,6 @@ class _EnumMeta(type):
 
 
 class Enum(metaclass=_EnumMeta):
-    __slots__ = ()
-
     def __getattr__(self, name):
         return getattr(self.value, name)
 

--- a/hikari/utilities/enums.py
+++ b/hikari/utilities/enums.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# cython: language_level=3
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Re-implementation of parts of Python's `enum` protocol to be lightweight."""
+from __future__ import annotations
+
+__all__: typing.List[str] = ["Enum"]
+
+import inspect
+import sys
+import types
+import typing
+
+if typing.TYPE_CHECKING:
+    # Hikari only uses these two types.
+    from enum import Enum
+else:
+    class _EnumNamespace(dict):
+        def __init__(self, base) -> None:
+            super().__init__()
+            self.base = base
+            self.names_to_values = {}
+            self.values_to_names = {}
+            self["__doc__"] = "An enumeration"
+            self.descriptors = {}
+
+        def __setitem__(self, name: str, value: typing.Any) -> None:
+            name = sys.intern(name)
+            if issubclass(self.base, str):
+                value = sys.intern(value)
+            else:
+                try:
+                    # This will fail if unhashable.
+                    hash(value)
+                except TypeError:
+                    raise TypeError("Cannot have unhashable values in this enum type") from None
+
+            if name.startswith("_"):
+                super().__setitem__(name, value)
+                return
+
+            if name == "" or name == "mro":
+                raise TypeError(f"Invalid enum member name: {name!r}")
+
+            if hasattr(value, "__get__") or hasattr(value, "__set__") or hasattr(value, "__del__"):
+                super().__setitem__(name, value)
+                return
+
+            if name in self.names_to_values:
+                raise TypeError("Cannot define same name twice")
+            if name in self.values_to_names:
+                raise TypeError("Cannot define same value twice")
+            if not isinstance(value, self.base):
+                raise TypeError("Enum values must be an instance of the base type of the enum")
+
+            self.names_to_values[name] = value
+            self.values_to_names[value] = name
+
+    def _make_delegate(name):
+        return property(lambda self: getattr(self._value_, name))
+
+    def _make_member_type(enum_type_name, base):
+        cls = type(f"{enum_type_name}Member", (base,), {"__slots__": ("_name_", "_value_")})
+
+        # Delegate members if possible.
+        for name, value in inspect.getmembers(base):
+            # __dunder_names__
+            if len(name) > 4 and name[:2] == name[-2:] == '__' and name[2] != '_' and name[-3] != '_':
+                continue
+            elif isinstance(value, staticmethod):
+                setattr(cls, name, value)
+            elif isinstance(value, classmethod):
+                setattr(cls, name, classmethod(value.__func__))
+            elif hasattr(value, "__get__") or hasattr(value, "__set__") or hasattr(value, "__delete__"):
+                setattr(cls, name, _make_delegate(name))
+            else:
+                setattr(cls, name, value)
+
+        cls.name = property(lambda self: self._name_)
+        cls.value = property(lambda self: self._value_)
+        cls.__str__ = lambda self: f"<{enum_type_name}.{self._name_}"
+        cls.__repr__ = lambda self: f"<{enum_type_name}.{self._name_}: {self._value_!r}>"
+        cls.__getattr__ = lambda self, _name: getattr(self._value_, _name)
+        return cls
+
+    # We refer to these from the metaclasses, but obviously this won't work
+    # until these classes are created, and since they use the metaclasses as
+    # a base metaclass, we have to give these values for _EnumMeta to not
+    # flake out when initializing them.
+    _Enum = NotImplemented
+
+    class _EnumMeta(type):
+        def __call__(cls, value):
+            return cls._values_to_names_[value]
+
+        def __init__(cls, name, bases, namespace):
+            super().__init__(name, bases, namespace)
+
+        @staticmethod
+        def __new__(mcs, name, bases, namespace):
+            global _Enum
+
+            if not bases:
+                if name == "Enum" and _Enum is NotImplemented:
+                    return (_Enum := super().__new__(mcs, name, bases, namespace))
+                raise TypeError("Expected two base classes for an enum")
+
+            base, enum_type = bases
+            new_namespace = {
+                "__objtype__": (member_type := _make_member_type(name, base)),
+                "_name2value_map_": (name2value := namespace.names_to_values),
+                "_name2member_map_": (name2member := {}),
+                "_value2member_map_": (value2member := {}),
+                "__members__": types.MappingProxyType(name2value),
+                **namespace,
+            }
+
+            for name, value in name2value.items():
+                member = member_type(_name_=name, _value_=value)
+                name2member[name] = member
+
+            return super().__new__(mcs, name, bases, new_namespace)
+
+        @staticmethod
+        def __prepare__(mcs, name, bases=()):
+            try:
+                # Fails if Enum is not defined. We check this in `__new__` properly.
+                base, enum_type = bases
+
+                if isinstance(base, _EnumMeta):
+                    raise TypeError("First base to an enum must be the type to combine with, not _EnumMeta")
+                if not isinstance(enum_type, _EnumMeta):
+                    raise TypeError("Second base to an enum must be the enum type (derived from _EnumMeta) to use")
+
+                return _EnumNamespace(base)
+            except ValueError:
+                return _EnumNamespace(object)
+
+    class Enum(metaclass=_EnumMeta):
+        pass
+
+    class DayOfWeek(str, Enum):
+        MON = "Monday"
+        TUE = "Tuesday"
+
+    print(dir(DayOfWeek), type(DayOfWeek), DayOfWeek.__members__, sep="\n")

--- a/hikari/utilities/enums.pyi
+++ b/hikari/utilities/enums.pyi
@@ -28,4 +28,7 @@
 # ship my own MyPy plugin for this, so just make MyPy think that the types
 # we are using are just aliases from the enum types in the standard library.
 
-from enum import Enum
+import enum as __enum
+Enum = __enum.Enum
+
+__all__ = ["Enum"]

--- a/hikari/utilities/enums.pyi
+++ b/hikari/utilities/enums.pyi
@@ -29,6 +29,7 @@
 # we are using are just aliases from the enum types in the standard library.
 
 import enum as __enum
+
 Enum = __enum.Enum
 
 __all__ = ["Enum"]

--- a/hikari/utilities/enums.pyi
+++ b/hikari/utilities/enums.pyi
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# cython: language_level=3
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Enums use a lot of internal voodoo that will not type check nicely, so we
+# skip that module with MyPy and just accept that "here be dragons".
+#
+# The caveat to implementing this is that MyPy has to have a special module to
+# understand how to use Python's enum types. I really don't want to have to
+# ship my own MyPy plugin for this, so just make MyPy think that the types
+# we are using are just aliases from the enum types in the standard library.
+
+from enum import Enum

--- a/scripts/enum_benchmark.py
+++ b/scripts/enum_benchmark.py
@@ -88,14 +88,28 @@ class BasicHikariEnum(str, hikari_enum.Enum):
 for i in range(100_000):
     assert sum(i for i in range(10)) > 0
 
-py_enum_time = timeit.timeit("BasicPyEnum('25')", number=1_000_000, globals=globals())
-hikari_enum_time = timeit.timeit("BasicHikariEnum('25')", number=1_000_000, globals=globals())
+py_enum_call_time = timeit.timeit("BasicPyEnum('25')", number=1_000_000, globals=globals())
+hikari_enum_call_time = timeit.timeit("BasicHikariEnum('25')", number=1_000_000, globals=globals())
+py_enum_delegate_to_map_time = timeit.timeit("BasicPyEnum._value2member_map_['25']", number=1_000_000, globals=globals())
+hikari_enum_delegate_to_map_time = timeit.timeit("BasicHikariEnum._value2member_map_['25']", number=1_000_000, globals=globals())
+py_enum_getitem_time = timeit.timeit("BasicPyEnum['z']", number=1_000_000, globals=globals())
+hikari_enum_getitem_time = timeit.timeit("BasicHikariEnum['z']", number=1_000_000, globals=globals())
 
-print("BasicPyEnum.__call__", py_enum_time, "µs")
-print("BasicHikariEnum.__call__", hikari_enum_time, "µs")
+print("BasicPyEnum.__call__('25')", py_enum_call_time, "µs")
+print("BasicHikariEnum.__call__('25')", hikari_enum_call_time, "µs")
+print("BasicPyEnum._value2member_map_['25']", py_enum_delegate_to_map_time, "µs")
+print("BasicHikariEnum._value2member_map['25']", hikari_enum_delegate_to_map_time, "µs")
+print("BasicPyEnum.__getitem__['z']", py_enum_getitem_time, "µs")
+print("BasicHikariEnum.__getitem__['z']", hikari_enum_getitem_time, "µs")
 
 print("BasicPyEnum.__call__ profile")
 cProfile.runctx("for i in range(1_000_000): BasicPyEnum('25')", globals=globals(), locals=locals())
 
 print("BasicHikariEnum.__call__ profile")
 cProfile.runctx("for i in range(1_000_000): BasicHikariEnum('25')", globals=globals(), locals=locals())
+
+print("BasicPyEnum.__getitem__ profile")
+cProfile.runctx("for i in range(1_000_000): BasicPyEnum['z']", globals=globals(), locals=locals())
+
+print("BasicHikariEnum.__getitem__ profile")
+cProfile.runctx("for i in range(1_000_000): BasicHikariEnum['z']", globals=globals(), locals=locals())

--- a/scripts/enum_benchmark.py
+++ b/scripts/enum_benchmark.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import cProfile
+import enum as py_enum
+import timeit
+
+from hikari.utilities import enums as hikari_enum
+
+
+class BasicPyEnum(str, py_enum.Enum):
+    a = "0"
+    b = "1"
+    c = "2"
+    d = "3"
+    e = "4"
+    f = "5"
+    g = "6"
+    h = "7"
+    i = "8"
+    j = "9"
+    k = "10"
+    l = "11"
+    m = "12"
+    n = "13"
+    o = "14"
+    p = "15"
+    q = "16"
+    r = "17"
+    s = "18"
+    t = "19"
+    u = "20"
+    v = "21"
+    w = "22"
+    x = "23"
+    y = "24"
+    z = "25"
+
+
+class BasicHikariEnum(str, hikari_enum.Enum):
+    a = "0"
+    b = "1"
+    c = "2"
+    d = "3"
+    e = "4"
+    f = "5"
+    g = "6"
+    h = "7"
+    i = "8"
+    j = "9"
+    k = "10"
+    l = "11"
+    m = "12"
+    n = "13"
+    o = "14"
+    p = "15"
+    q = "16"
+    r = "17"
+    s = "18"
+    t = "19"
+    u = "20"
+    v = "21"
+    w = "22"
+    x = "23"
+    y = "24"
+    z = "25"
+
+
+# Dummy work to churn the CPU up.
+for i in range(100_000):
+    assert sum(i for i in range(10)) > 0
+
+py_enum_time = timeit.timeit("BasicPyEnum('25')", number=1_000_000, globals=globals())
+hikari_enum_time = timeit.timeit("BasicHikariEnum('25')", number=1_000_000, globals=globals())
+
+print("BasicPyEnum.__call__", py_enum_time, "µs")
+print("BasicHikariEnum.__call__", hikari_enum_time, "µs")
+
+print("BasicPyEnum.__call__ profile")
+cProfile.runctx("for i in range(1_000_000): BasicPyEnum('25')", globals=globals(), locals=locals())
+
+print("BasicHikariEnum.__call__ profile")
+cProfile.runctx("for i in range(1_000_000): BasicHikariEnum('25')", globals=globals(), locals=locals())

--- a/scripts/enum_benchmark.py
+++ b/scripts/enum_benchmark.py
@@ -90,8 +90,12 @@ for i in range(100_000):
 
 py_enum_call_time = timeit.timeit("BasicPyEnum('25')", number=1_000_000, globals=globals())
 hikari_enum_call_time = timeit.timeit("BasicHikariEnum('25')", number=1_000_000, globals=globals())
-py_enum_delegate_to_map_time = timeit.timeit("BasicPyEnum._value2member_map_['25']", number=1_000_000, globals=globals())
-hikari_enum_delegate_to_map_time = timeit.timeit("BasicHikariEnum._value2member_map_['25']", number=1_000_000, globals=globals())
+py_enum_delegate_to_map_time = timeit.timeit(
+    "BasicPyEnum._value2member_map_['25']", number=1_000_000, globals=globals()
+)
+hikari_enum_delegate_to_map_time = timeit.timeit(
+    "BasicHikariEnum._value2member_map_['25']", number=1_000_000, globals=globals()
+)
 py_enum_getitem_time = timeit.timeit("BasicPyEnum['z']", number=1_000_000, globals=globals())
 hikari_enum_getitem_time = timeit.timeit("BasicHikariEnum['z']", number=1_000_000, globals=globals())
 

--- a/tests/hikari/utilities/test_enums.py
+++ b/tests/hikari/utilities/test_enums.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import mock
+import pytest
+
+from hikari.utilities import enums
+
+
+class TestEnum:
+    @mock.patch.object(enums, "_Enum", new=NotImplemented)
+    def test_init_first_enum_type_populates_Enum(self):
+        class Enum(metaclass=enums._EnumMeta):
+            pass
+
+        assert enums._Enum is Enum
+
+    @mock.patch.object(enums, "_Enum", new=NotImplemented)
+    def test_init_first_enum_type_with_wrong_name_and_no_bases_raises_TypeError(self):
+        with pytest.raises(TypeError):
+
+            class Potato(metaclass=enums._EnumMeta):
+                pass
+
+        assert enums._Enum is NotImplemented
+
+    def test_init_second_enum_type_with_no_bases_does_not_change_Enum_attribute_and_raises_TypeError(self):
+        expect = enums._Enum
+
+        with pytest.raises(TypeError):
+
+            class Enum(metaclass=enums._EnumMeta):
+                pass
+
+        assert enums._Enum is expect
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [([str], {"metaclass": enums._EnumMeta}), ([enums.Enum], {"metaclass": enums._EnumMeta}), ([enums.Enum], {})],
+    )
+    def test_init_enum_type_with_one_base_is_TypeError(self, args, kwargs):
+        with pytest.raises(TypeError):
+
+            class Enum(*args, **kwargs):
+                pass
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            ([enums.Enum, str], {"metaclass": enums._EnumMeta}),
+            ([enums.Enum, str], {}),
+        ],
+    )
+    def test_init_enum_type_with_bases_in_wrong_order_is_TypeError(self, args, kwargs):
+        with pytest.raises(TypeError):
+
+            class Enum(*args, **kwargs):
+                pass
+
+    def test_init_enum_type_default_docstring_set(self):
+        class Enum(str, enums.Enum):
+            pass
+
+        assert Enum.__doc__ == "An enumeration."
+
+    def test_init_enum_type_disallows_objects_that_are_not_instances_of_the_first_base(self):
+        with pytest.raises(TypeError):
+
+            class Enum(str, enums.Enum):
+                foo = 1
+
+    def test_init_enum_type_allows_any_object_if_it_has_a_dunder_name(self):
+        class Enum(str, enums.Enum):
+            __foo__ = 1
+            __bar = 2
+
+        assert Enum is not None
+
+    def test_init_enum_type_allows_any_object_if_it_has_a_sunder_name(self):
+        class Enum(str, enums.Enum):
+            _foo_ = 1
+            _bar = 2
+
+        assert Enum is not None
+
+    def test_init_enum_type_allows_methods(self):
+        class Enum(int, enums.Enum):
+            def foo(self):
+                return "foo"
+
+        assert Enum.foo(12) == "foo"
+
+    def test_init_enum_type_allows_classmethods(self):
+        class Enum(int, enums.Enum):
+            @classmethod
+            def foo(cls):
+                assert cls is Enum
+                return "foo"
+
+        assert Enum.foo() == "foo"
+
+    def test_init_enum_type_allows_staticmethods(self):
+        class Enum(int, enums.Enum):
+            @staticmethod
+            def foo():
+                return "foo"
+
+        assert Enum.foo() == "foo"
+
+    def test_init_enum_type_allows_descriptors(self):
+        class Enum(int, enums.Enum):
+            @property
+            def foo(self):
+                return "foo"
+
+        assert isinstance(Enum.foo, property)
+
+    def test_init_enum_type_maps_names_in___members__(self):
+        class Enum(int, enums.Enum):
+            foo = 9
+            bar = 18
+            baz = 27
+
+            @staticmethod
+            def sm():
+                pass
+
+            @classmethod
+            def cm(cls):
+                pass
+
+            def m(self):
+                pass
+
+            @property
+            def p(self):
+                pass
+
+            __dunder__ = "aaa"
+            _sunder_ = "bbb"
+            __priv = "ccc"
+            _prot = "ddd"
+
+        assert Enum.__members__ == {"foo": 9, "bar": 18, "baz": 27}


### PR DESCRIPTION
FIxes #151, reimplements enum to be faster.

```
BasicPyEnum.__call__('25') 0.43657039100071415 µs
BasicHikariEnum.__call__('25') 0.19885178900040046 µs
BasicPyEnum._value2member_map_['25'] 0.09891081800014945 µs
BasicHikariEnum._value2member_map['25'] 0.1033127640002931 µs
BasicPyEnum.__getitem__['z'] 0.16736914299872296 µs
BasicHikariEnum.__getitem__['z'] 0.15685381999901438 µs
BasicPyEnum.__call__ profile
         2000003 function calls in 0.744 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.249    0.249    0.744    0.744 <string>:1(<module>)
  1000000    0.274    0.000    0.495    0.000 enum.py:283(__call__)
  1000000    0.221    0.000    0.221    0.000 enum.py:562(__new__)
        1    0.000    0.000    0.744    0.744 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


BasicHikariEnum.__call__ profile
         1000003 function calls in 0.340 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.183    0.183    0.340    0.340 <string>:1(<module>)
  1000000    0.157    0.000    0.157    0.000 enums.py:115(__call__)
        1    0.000    0.000    0.340    0.340 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


BasicPyEnum.__getitem__ profile
         1000003 function calls in 0.331 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.165    0.165    0.331    0.331 <string>:1(<module>)
  1000000    0.166    0.000    0.166    0.000 enum.py:348(__getitem__)
        1    0.000    0.000    0.331    0.331 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


BasicHikariEnum.__getitem__ profile
         1000003 function calls in 0.318 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.159    0.159    0.318    0.318 <string>:1(<module>)
  1000000    0.158    0.000    0.158    0.000 enums.py:141(__getitem__)
        1    0.000    0.000    0.318    0.318 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```