### PR TITLE
Remove blocked off integration endpoints

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2511,33 +2511,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def edit_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
-        *,
-        expire_behaviour: undefined.UndefinedOr[guilds.IntegrationExpireBehaviour] = undefined.UNDEFINED,
-        expire_grace_period: undefined.UndefinedOr[date.Intervalish] = undefined.UNDEFINED,
-        enable_emojis: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
-        ...
-
-    @abc.abstractmethod
     async def delete_integration(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         integration: snowflakes.SnowflakeishOr[guilds.Integration],
         *,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
-        ...
-
-    @abc.abstractmethod
-    async def sync_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
     ) -> None:
         ...
 

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2262,24 +2262,6 @@ class RESTClientImpl(rest_api.RESTClient):
         response = typing.cast(data_binding.JSONArray, raw_response)
         return data_binding.cast_json_array(response, self._entity_factory.deserialize_integration)
 
-    async def edit_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
-        *,
-        expire_behaviour: undefined.UndefinedOr[guilds.IntegrationExpireBehaviour] = undefined.UNDEFINED,
-        expire_grace_period: undefined.UndefinedOr[date.Intervalish] = undefined.UNDEFINED,
-        enable_emojis: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
-        route = routes.PATCH_GUILD_INTEGRATION.compile(guild=guild, integration=integration)
-        body = data_binding.JSONObjectBuilder()
-        body.put("expire_behaviour", expire_behaviour)
-        body.put("expire_grace_period", expire_grace_period, conversion=date.timespan_to_int)
-        # Inconsistent naming in the API itself, so I have changed the name.
-        body.put("enable_emoticons", enable_emojis)
-        await self._request(route, json=body, reason=reason)
-
     async def delete_integration(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
@@ -2289,14 +2271,6 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> None:
         route = routes.DELETE_GUILD_INTEGRATION.compile(guild=guild, integration=integration)
         await self._request(route, reason=reason)
-
-    async def sync_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
-    ) -> None:
-        route = routes.POST_GUILD_INTEGRATION_SYNC.compile(guild=guild, integration=integration)
-        await self._request(route)
 
     async def fetch_widget(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> guilds.GuildWidget:
         route = routes.GET_GUILD_WIDGET.compile(guild=guild)

--- a/hikari/utilities/routes.py
+++ b/hikari/utilities/routes.py
@@ -354,11 +354,9 @@ DELETE_GUILD_EMOJI: typing.Final[Route] = Route(DELETE, "/guilds/{guild}/emojis/
 
 GET_GUILD_EMOJIS: typing.Final[Route] = Route(GET, "/guilds/{guild}/emojis")
 POST_GUILD_EMOJIS: typing.Final[Route] = Route(POST, "/guilds/{guild}/emojis")
-PATCH_GUILD_INTEGRATION: typing.Final[Route] = Route(PATCH, "/guilds/{guild}/integrations/{integration}")
-DELETE_GUILD_INTEGRATION: typing.Final[Route] = Route(DELETE, "/guilds/{guild}/integrations/{integration}")
 
 GET_GUILD_INTEGRATIONS: typing.Final[Route] = Route(GET, "/guilds/{guild}/integrations")
-POST_GUILD_INTEGRATION_SYNC: typing.Final[Route] = Route(POST, "/guilds/{guild}/integrations/{integration}")
+DELETE_GUILD_INTEGRATION: typing.Final[Route] = Route(DELETE, "/guilds/{guild}/integrations/{integration}")
 
 GET_GUILD_INVITES: typing.Final[Route] = Route(GET, "/guilds/{guild}/invites")
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2379,38 +2379,12 @@ class TestRESTClientImplAsync:
             [mock.call({"id": "456"}), mock.call({"id": "789"})]
         )
 
-    async def test_edit_integration(self, rest_client):
-        expected_route = routes.PATCH_GUILD_INTEGRATION.compile(guild=123, integration=789)
-        expected_json = {
-            "expire_behaviour": 0,
-            "expire_grace_period": 60,
-            "enable_emoticons": True,
-        }
-        rest_client._request = mock.AsyncMock(return_value={"id": "456"})
-
-        await rest_client.edit_integration(
-            StubModel(123),
-            StubModel(789),
-            expire_behaviour=guilds.IntegrationExpireBehaviour.REMOVE_ROLE,
-            expire_grace_period=60,
-            enable_emojis=True,
-            reason="change of mind",
-        )
-        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="change of mind")
-
     async def test_delete_integration(self, rest_client):
         expected_route = routes.DELETE_GUILD_INTEGRATION.compile(guild=123, integration=456)
         rest_client._request = mock.AsyncMock()
 
         await rest_client.delete_integration(StubModel(123), StubModel(456), reason="dont need it anymore")
         rest_client._request.assert_awaited_once_with(expected_route, reason="dont need it anymore")
-
-    async def test_sync_integration(self, rest_client):
-        expected_route = routes.POST_GUILD_INTEGRATION_SYNC.compile(guild=123, integration=456)
-        rest_client._request = mock.AsyncMock()
-
-        await rest_client.sync_integration(StubModel(123), StubModel(456))
-        rest_client._request.assert_awaited_once_with(expected_route)
 
     async def test_fetch_widget(self, rest_client):
         widget = StubModel(789)


### PR DESCRIPTION
Looks like discord blocked off some integration endpoints to prevent bots from using them.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.