### PR TITLE
Improve `fetch_ban` to return None if the user ban is not found

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2329,7 +2329,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
-    ) -> guilds.GuildMemberBan:
+    ) -> typing.Optional[guilds.GuildMemberBan]:
         ...
 
     @abc.abstractmethod


### PR DESCRIPTION
Also works on v8 of the REST

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Close #209 
