### PR TITLE
Comparing applications.TeamMember with guilds.Member and users.User

### DIFF
--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -265,31 +265,37 @@ class TeamMembershipState(enum.IntEnum):
 
 
 @attr_extensions.with_copy
-@attr.s(eq=True, hash=True, init=True, kw_only=True, slots=True, weakref_slot=False)
+@attr.s(eq=False, hash=False, init=True, kw_only=True, slots=True, weakref_slot=False)
 class TeamMember:
     """Represents a member of a Team."""
 
-    app: traits.RESTAware = attr.ib(repr=False, eq=False, hash=False, metadata={attr_extensions.SKIP_DEEP_COPY: True})
+    app: traits.RESTAware = attr.ib(repr=False, metadata={attr_extensions.SKIP_DEEP_COPY: True})
     """The client application that models may use for procedures."""
 
-    membership_state: TeamMembershipState = attr.ib(eq=False, hash=False, repr=False)
+    membership_state: TeamMembershipState = attr.ib(repr=False)
     """The state of this user's membership."""
 
-    permissions: typing.Sequence[str] = attr.ib(eq=False, hash=False, repr=False)
+    permissions: typing.Sequence[str] = attr.ib(repr=False)
     """This member's permissions within a team.
 
     At the time of writing, this will always be a sequence of one `builtins.str`,
     which will always be `"*"`. This may change in the future, however.
     """
 
-    team_id: snowflakes.Snowflake = attr.ib(eq=True, hash=True, repr=True)
+    team_id: snowflakes.Snowflake = attr.ib(repr=True)
     """The ID of the team this member belongs to."""
 
-    user: users.User = attr.ib(eq=True, hash=True, repr=True)
+    user: users.User = attr.ib(repr=True)
     """The user representation of this team member."""
 
     def __str__(self) -> str:
         return str(self.user)
+
+    def __hash__(self) -> int:
+        return hash(self.user)
+
+    def __eq__(self, other: object) -> bool:
+        return self.user == other
 
 
 @attr_extensions.with_copy

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -279,11 +279,11 @@ class GuildWidget:
 
 
 @attr_extensions.with_copy
-@attr.s(eq=True, hash=True, init=True, kw_only=True, slots=True, weakref_slot=False)
+@attr.s(eq=False, hash=False, init=True, kw_only=True, slots=True, weakref_slot=False)
 class Member(users.User):
     """Used to represent a guild bound member."""
 
-    guild_id: snowflakes.Snowflake = attr.ib(eq=True, hash=True, repr=True)
+    guild_id: snowflakes.Snowflake = attr.ib(repr=True)
     """The ID of the guild this member belongs to."""
 
     # This is technically optional, since UPDATE MEMBER and MESSAGE CREATE
@@ -293,14 +293,10 @@ class Member(users.User):
     # can assume this is always set, and thus we are always able to get info
     # such as the ID of the user this member represents.
     # TODO: make member generic on this field (e.g. Member[PartialUser], Member[UserImpl], Member[OwnUser], etc)?
-    user: users.User = attr.ib(eq=True, hash=True, repr=True)
+    user: users.User = attr.ib(repr=True)
     """This member's corresponding user object."""
 
-    nickname: undefined.UndefinedNoneOr[str] = attr.ib(
-        eq=False,
-        hash=False,
-        repr=True,
-    )
+    nickname: undefined.UndefinedNoneOr[str] = attr.ib(repr=True)
     """This member's nickname.
 
     This will be `builtins.None` if not set.
@@ -309,26 +305,26 @@ class Member(users.User):
     In this case, this will be undefined.
     """
 
-    role_ids: typing.Sequence[snowflakes.Snowflake] = attr.ib(eq=False, hash=False, repr=False)
+    role_ids: typing.Sequence[snowflakes.Snowflake] = attr.ib(repr=False)
     """A sequence of the IDs of the member's current roles."""
 
-    joined_at: datetime.datetime = attr.ib(eq=False, hash=False, repr=True)
+    joined_at: datetime.datetime = attr.ib(repr=True)
     """The datetime of when this member joined the guild they belong to."""
 
-    premium_since: typing.Optional[datetime.datetime] = attr.ib(eq=False, hash=False, repr=False)
+    premium_since: typing.Optional[datetime.datetime] = attr.ib(repr=False)
     """The datetime of when this member started "boosting" this guild.
 
     Will be `builtins.None` if the member is not a premium user.
     """
 
-    is_deaf: undefined.UndefinedOr[bool] = attr.ib(eq=False, hash=False, repr=False)
+    is_deaf: undefined.UndefinedOr[bool] = attr.ib(repr=False)
     """`builtins.True` if this member is deafened in the current voice channel.
 
     This will be `hikari.undefined.UndefinedType if it's state is
     unknown.
     """
 
-    is_mute: undefined.UndefinedOr[bool] = attr.ib(eq=False, hash=False, repr=False)
+    is_mute: undefined.UndefinedOr[bool] = attr.ib(repr=False)
     """`builtins.True` if this member is muted in the current voice channel.
 
     This will be `hikari.undefined.UndefinedType if it's state is unknown.
@@ -451,6 +447,12 @@ class Member(users.User):
 
     def __str__(self) -> str:
         return str(self.user)
+
+    def __hash__(self) -> int:
+        return hash(self.user)
+
+    def __eq__(self, other: object) -> bool:
+        return self.user == other
 
 
 @attr_extensions.with_copy

--- a/tests/hikari/integration/__init__.py
+++ b/tests/hikari/integration/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Tomxey
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/tests/hikari/integration/test_users_comparison.py
+++ b/tests/hikari/integration/test_users_comparison.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Tomxey
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import datetime
+
+import mock
+
+from hikari import applications
+from hikari import guilds
+from hikari import snowflakes
+from hikari import users
+
+
+def assert_objects_equal(a, b):
+    assert a == b
+    assert b == a
+    assert not a != b
+    assert not b != a
+    assert hash(a) == hash(b)
+
+
+def assert_objects_not_equal(a, b):
+    assert a != b
+    assert b != a
+    assert not a == b
+    assert not b == a
+
+
+def make_user(user_id, username):
+    return users.UserImpl(
+        app=mock.Mock(),
+        id=snowflakes.Snowflake(user_id),
+        discriminator="0001",
+        username=username,
+        avatar_hash=None,
+        is_bot=False,
+        is_system=False,
+        flags=users.UserFlag.NONE,
+    )
+
+
+def make_team_member(user_id, username):
+    user = make_user(user_id, username)
+    return applications.TeamMember(
+        app=user.app,
+        membership_state=applications.TeamMembershipState.ACCEPTED,
+        permissions="*",
+        team_id=snowflakes.Snowflake(1234),
+        user=user,
+    )
+
+
+def make_guild_member(user_id, username):
+    user = make_user(user_id, username)
+    return guilds.Member(
+        user=user,
+        guild_id=snowflakes.Snowflake(2233),
+        role_ids=[],
+        joined_at=datetime.datetime.now(),
+        nickname=user.username,
+        premium_since=None,
+        is_deaf=False,
+        is_mute=False,
+    )
+
+
+class TestUsersComparison:
+    def test_user_equal_to_team_member(self):
+        user = make_user(1, "yasuoop")
+        team_member = make_team_member(1, "yasuoop")
+        assert_objects_equal(user, team_member)
+
+    def test_user_not_equal_to_team_member(self):
+        user = make_user(1, "yasuoop")
+        team_member = make_team_member(2, "taricop")
+        assert_objects_not_equal(user, team_member)
+
+    def test_user_equal_to_guild_member(self):
+        user = make_user(1, "yasuoop")
+        guild_member = make_guild_member(1, "yasuoop")
+        assert_objects_equal(user, guild_member)
+
+    def test_user_not_equal_to_guild_member(self):
+        user = make_user(1, "yasuoop")
+        guild_member = make_guild_member(2, "taricop")
+        assert_objects_not_equal(user, guild_member)
+
+    def test_team_member_equal_to_guild_member(self):
+        team_member = make_team_member(1, "yasuoop")
+        guild_member = make_guild_member(1, "yasuoop")
+        assert_objects_equal(team_member, guild_member)
+
+    def test_team_member_not_equal_to_guild_member(self):
+        team_member = make_team_member(1, "yasuoop")
+        guild_member = make_guild_member(2, "taricop")
+        assert_objects_not_equal(team_member, guild_member)


### PR DESCRIPTION
### Summary
This PR modifies `__hash__` and `__eq__` methods of `applications.TeamMember` and `guilds.Member` so that they are always compared according to their `user` field (other fields don't matter anymore).
Custom `__hash__` and `__eq__` had to be written, resigning from the ones generated by the `@attr` decorator(or maybe I'm wrong, I don't have experience with attrs pakage).

I'm not sure if this is the best solution as now other fields of `TeamMember` and `Member` are always ignored for every comparison, is this desired?

Another way to make the `in` operator work (see linked issue) would be to define methods like `__contains__`, `__getitem__` and so on... on the `applications.Team` class or on some new class like `applications.TeamMembers`.
These methods could then support different object types passed as arguments.

@nekokatt What do you think?

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
This PR fixes #194 