### PR TITLE
Task/218 dm message event naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,21 @@ import hikari
 
 bot = hikari.Bot(token="...")
 
-
 @bot.listen()
 async def ping(event: hikari.GuildMessageCreateEvent) -> None:
     # If a non-bot user sends a message "hk.ping", respond with "Pong!"
+    # We check there is actually content first, if no message content exists,
+    # we would get `None' here.
+    if event.is_bot or not event.content:
+        return
 
-    if not event.is_bot and event.message.content.startswith("hk.ping"):
+    if event.content.startswith("hk.ping"):
         await event.message.reply("Pong!")
-
 
 bot.run()
 ```
 
-This will only respond to messages created in guilds. You can use `PrivateMessageCreateEvent`
+This will only respond to messages created in guilds. You can use `DMMessageCreateEvent`
 instead to only listen on DMs, or `MessageCreateEvent` to listen to both DMs and guild-based
 messages.
 
@@ -190,7 +192,6 @@ everything builds and is correct.
 ### Where can I start?
 
 Check out the issues tab on GitHub. If you are nervous, look for issues
-marked as ![good-first-issue-badge](https://img.shields.io/github/labels/nekokatt/hikari/good%20first%20issue) for
- something easy to start with!
+marked as "good first issue" for something easy to start with!
 
 [![good-first-issues](https://img.shields.io/github/issues/nekokatt/hikari/good%20first%20issue)](https://github.com/nekokatt/hikari/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async def ping(event: hikari.GuildMessageCreateEvent) -> None:
 bot.run()
 ```
 
-This will only respond to messages created in guilds. You can use `PrivateMessageCreateEvent` 
+This will only respond to messages created in guilds. You can use `PrivateMessageCreateEvent`
 instead to only listen on DMs, or `MessageCreateEvent` to listen to both DMs and guild-based
 messages.
 
@@ -64,10 +64,10 @@ Also note that you could pass extra options to `bot.run` during development, for
 ```py
 bot.run(
     asyncio_debug=True,             # enable asyncio debug to detect blocking and slow code.
-    
-    coroutine_tracking_depth=20,    # enable tracking of coroutines, makes some asyncio 
+
+    coroutine_tracking_depth=20,    # enable tracking of coroutines, makes some asyncio
                                     # errors clearer.
-                                    
+
     propagate_interrupts=True,      # Any OS interrupts get rethrown as errors.
 )
 ```

--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -149,6 +149,27 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
+        """Get a guild from the cache.
+
+        !!! warning
+            This will return a guild regardless of whether it is available or
+            not. To only query available guilds, use `get_available_guild`
+            instead. Likewise, to only query unavailable guilds, use
+            `get_unavailable_guild`.
+
+        Parameters
+        ----------
+        guild_id : hikari.snowflakes.Snowflake
+            The ID of the guild to get from the cache.
+
+        Returns
+        -------
+        typing.Optional[hikari.guilds.GatewayGuild]
+            The object of the guild if found, else `builtins.None`.
+        """
+
+    @abc.abstractmethod
     def get_available_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
         """Get the object of an available guild from the cache.
 
@@ -160,7 +181,7 @@ class Cache(abc.ABC):
         Returns
         -------
         typing.Optional[hikari.guilds.GatewayGuild]
-            The object of the guild if found, else None.
+            The object of the guild if found, else `builtins.None`.
         """
 
     @abc.abstractmethod
@@ -181,7 +202,7 @@ class Cache(abc.ABC):
         Returns
         -------
         typing.Optional[hikari.guilds.GatewayGuild]
-            The object of the guild if found, else None.
+            The object of the guild if found, else `builtins.None`.
         """
 
     @abc.abstractmethod

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -29,19 +29,19 @@ from __future__ import annotations
 __all__: typing.List[str] = [
     "ChannelEvent",
     "GuildChannelEvent",
-    "PrivateChannelEvent",
+    "DMChannelEvent",
     "ChannelCreateEvent",
     "GuildChannelCreateEvent",
-    "PrivateChannelCreateEvent",
+    "DMChannelCreateEvent",
     "ChannelUpdateEvent",
     "GuildChannelUpdateEvent",
-    "PrivateChannelUpdateEvent",
+    "DMChannelUpdateEvent",
     "ChannelDeleteEvent",
     "GuildChannelDeleteEvent",
-    "PrivateChannelDeleteEvent",
+    "DMChannelDeleteEvent",
     "PinsUpdateEvent",
     "GuildPinsUpdateEvent",
-    "PrivatePinsUpdateEvent",
+    "DMPinsUpdateEvent",
     "InviteCreateEvent",
     "InviteDeleteEvent",
     "WebhookUpdateEvent",
@@ -194,7 +194,7 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
 
 
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivateChannelEvent(ChannelEvent, abc.ABC):
+class DMChannelEvent(ChannelEvent, abc.ABC):
     """Event base for any channel-bound event in private messages."""
 
     @property
@@ -283,7 +283,7 @@ class GuildChannelCreateEvent(GuildChannelEvent, ChannelCreateEvent):
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGES)
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivateChannelCreateEvent(PrivateChannelEvent, ChannelCreateEvent):
+class DMChannelCreateEvent(DMChannelEvent, ChannelCreateEvent):
     """Event fired when a private channel is created."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -354,7 +354,7 @@ class GuildChannelUpdateEvent(GuildChannelEvent, ChannelUpdateEvent):
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGES)
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivateChannelUpdateEvent(PrivateChannelEvent, ChannelUpdateEvent):
+class DMChannelUpdateEvent(DMChannelEvent, ChannelUpdateEvent):
     """Event fired when a private channel is edited."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -436,7 +436,7 @@ class GuildChannelDeleteEvent(GuildChannelEvent, ChannelDeleteEvent):
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGES)
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivateChannelDeleteEvent(PrivateChannelEvent, ChannelDeleteEvent):
+class DMChannelDeleteEvent(DMChannelEvent, ChannelDeleteEvent):
     """Event fired when a private channel is deleted."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -573,7 +573,7 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
 # TODO: This is not documented as having an intent, is this right? The guild version requires GUILDS intent.
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivatePinsUpdateEvent(PinsUpdateEvent, PrivateChannelEvent):
+class DMPinsUpdateEvent(PinsUpdateEvent, DMChannelEvent):
     """Event fired when a message is pinned/unpinned in a private channel."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 __all__: typing.List[str] = [
     "ReactionEvent",
     "GuildReactionEvent",
-    "PrivateReactionEvent",
+    "DMReactionEvent",
     "ReactionAddEvent",
     "ReactionDeleteEvent",
     "ReactionDeleteEmojiEvent",
@@ -35,10 +35,10 @@ __all__: typing.List[str] = [
     "GuildReactionDeleteEvent",
     "GuildReactionDeleteEmojiEvent",
     "GuildReactionDeleteAllEvent",
-    "PrivateReactionAddEvent",
-    "PrivateReactionDeleteEvent",
-    "PrivateReactionDeleteEmojiEvent",
-    "PrivateReactionDeleteAllEvent",
+    "DMReactionAddEvent",
+    "DMReactionDeleteEvent",
+    "DMReactionDeleteEmojiEvent",
+    "DMReactionDeleteAllEvent",
 ]
 
 import abc
@@ -106,7 +106,7 @@ class GuildReactionEvent(ReactionEvent, abc.ABC):
 
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGE_REACTIONS)
-class PrivateReactionEvent(ReactionEvent, abc.ABC):
+class DMReactionEvent(ReactionEvent, abc.ABC):
     """Event base for any reaction-bound event in private messages."""
 
 
@@ -314,7 +314,7 @@ class GuildReactionDeleteAllEvent(GuildReactionEvent, ReactionDeleteAllEvent):
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGE_REACTIONS)
-class PrivateReactionAddEvent(PrivateReactionEvent, ReactionAddEvent):
+class DMReactionAddEvent(DMReactionEvent, ReactionAddEvent):
     """Event fired when a reaction is added to a guild message."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -339,7 +339,7 @@ class PrivateReactionAddEvent(PrivateReactionEvent, ReactionAddEvent):
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGE_REACTIONS)
-class PrivateReactionDeleteEvent(PrivateReactionEvent, ReactionDeleteEvent):
+class DMReactionDeleteEvent(DMReactionEvent, ReactionDeleteEvent):
     """Event fired when a reaction is removed from a private message."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -364,7 +364,7 @@ class PrivateReactionDeleteEvent(PrivateReactionEvent, ReactionDeleteEvent):
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGE_REACTIONS)
-class PrivateReactionDeleteEmojiEvent(PrivateReactionEvent, ReactionDeleteEmojiEvent):
+class DMReactionDeleteEmojiEvent(DMReactionEvent, ReactionDeleteEmojiEvent):
     """Event fired when an emoji is removed from a private message's reactions."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
@@ -386,7 +386,7 @@ class PrivateReactionDeleteEmojiEvent(PrivateReactionEvent, ReactionDeleteEmojiE
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGE_REACTIONS)
-class PrivateReactionDeleteAllEvent(PrivateReactionEvent, ReactionDeleteAllEvent):
+class DMReactionDeleteAllEvent(DMReactionEvent, ReactionDeleteAllEvent):
     """Event fired when all of a private message's reactions are removed."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 __all__: typing.List[str] = [
     "TypingEvent",
     "GuildTypingEvent",
-    "PrivateTypingEvent",
+    "DMTypingEvent",
 ]
 
 import abc
@@ -261,7 +261,7 @@ class GuildTypingEvent(TypingEvent):
 @base_events.requires_intents(intents.Intents.PRIVATE_MESSAGES)
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
-class PrivateTypingEvent(TypingEvent):
+class DMTypingEvent(TypingEvent):
     """Event fired when a user starts typing in a guild channel."""
 
     app: traits.RESTAware = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -66,7 +66,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         if isinstance(channel, channel_models.GuildChannel):
             return channel_events.GuildChannelCreateEvent(app=self._app, shard=shard, channel=channel)
         if isinstance(channel, channel_models.PrivateChannel):
-            return channel_events.PrivateChannelCreateEvent(app=self._app, shard=shard, channel=channel)
+            return channel_events.DMChannelCreateEvent(app=self._app, shard=shard, channel=channel)
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
 
     def deserialize_channel_update_event(
@@ -76,7 +76,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         if isinstance(channel, channel_models.GuildChannel):
             return channel_events.GuildChannelUpdateEvent(app=self._app, shard=shard, channel=channel)
         if isinstance(channel, channel_models.PrivateChannel):
-            return channel_events.PrivateChannelUpdateEvent(app=self._app, shard=shard, channel=channel)
+            return channel_events.DMChannelUpdateEvent(app=self._app, shard=shard, channel=channel)
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
 
     def deserialize_channel_delete_event(
@@ -86,7 +86,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         if isinstance(channel, channel_models.GuildChannel):
             return channel_events.GuildChannelDeleteEvent(app=self._app, shard=shard, channel=channel)
         if isinstance(channel, channel_models.PrivateChannel):
-            return channel_events.PrivateChannelDeleteEvent(app=self._app, shard=shard, channel=channel)
+            return channel_events.DMChannelDeleteEvent(app=self._app, shard=shard, channel=channel)
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
 
     def deserialize_channel_pins_update_event(
@@ -109,7 +109,7 @@ class EventFactoryImpl(event_factory.EventFactory):
                 last_pin_timestamp=last_pin_timestamp,
             )
 
-        return channel_events.PrivatePinsUpdateEvent(
+        return channel_events.DMPinsUpdateEvent(
             app=self._app, shard=shard, channel_id=channel_id, last_pin_timestamp=last_pin_timestamp
         )
 
@@ -145,7 +145,7 @@ class EventFactoryImpl(event_factory.EventFactory):
                 user=member,
             )
 
-        return typing_events.PrivateTypingEvent(
+        return typing_events.DMTypingEvent(
             app=self._app, shard=shard, channel_id=channel_id, user_id=user_id, timestamp=timestamp
         )
 
@@ -344,7 +344,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         message = self._app.entity_factory.deserialize_message(payload)
 
         if message.guild_id is None:
-            return message_events.PrivateMessageCreateEvent(app=self._app, shard=shard, message=message)
+            return message_events.DMMessageCreateEvent(app=self._app, shard=shard, message=message)
 
         return message_events.GuildMessageCreateEvent(app=self._app, shard=shard, message=message)
 
@@ -354,7 +354,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         message = self._app.entity_factory.deserialize_partial_message(payload)
 
         if message.guild_id is None:
-            return message_events.PrivateMessageUpdateEvent(app=self._app, shard=shard, message=message)
+            return message_events.DMMessageUpdateEvent(app=self._app, shard=shard, message=message)
 
         return message_events.GuildMessageUpdateEvent(app=self._app, shard=shard, message=message)
 
@@ -364,7 +364,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         message = self._app.entity_factory.deserialize_partial_message(payload)
 
         if message.guild_id is None:
-            return message_events.PrivateMessageDeleteEvent(app=self._app, shard=shard, message=message)
+            return message_events.DMMessageDeleteEvent(app=self._app, shard=shard, message=message)
 
         return message_events.GuildMessageDeleteEvent(app=self._app, shard=shard, message=message)
 
@@ -402,7 +402,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             )
 
         user_id = snowflakes.Snowflake(payload["user_id"])
-        return reaction_events.PrivateReactionAddEvent(
+        return reaction_events.DMReactionAddEvent(
             app=self._app,
             shard=shard,
             channel_id=channel_id,
@@ -430,7 +430,7 @@ class EventFactoryImpl(event_factory.EventFactory):
                 emoji=emoji,
             )
 
-        return reaction_events.PrivateReactionDeleteEvent(
+        return reaction_events.DMReactionDeleteEvent(
             app=self._app,
             shard=shard,
             user_id=user_id,
@@ -455,7 +455,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             )
 
         # TODO: check if this can even occur.
-        return reaction_events.PrivateReactionDeleteAllEvent(
+        return reaction_events.DMReactionDeleteAllEvent(
             app=self._app,
             shard=shard,
             channel_id=channel_id,
@@ -480,7 +480,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             )
 
         # TODO: check if this can even occur.
-        return reaction_events.PrivateReactionDeleteEmojiEvent(
+        return reaction_events.DMReactionDeleteEmojiEvent(
             app=self._app,
             shard=shard,
             emoji=emoji,

--- a/hikari/impl/stateful_cache.py
+++ b/hikari/impl/stateful_cache.py
@@ -428,6 +428,11 @@ class StatefulCacheImpl(cache.MutableCache):
 
         return copy.copy(guild_record.guild)
 
+    def get_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
+        if (guild := self._get_guild(guild_id, availability=True)) is not None:
+            return guild
+        return self._get_guild(guild_id, availability=False)
+
     def get_available_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
         return self._get_guild(guild_id, availability=True)
 

--- a/hikari/impl/stateless_cache.py
+++ b/hikari/impl/stateless_cache.py
@@ -123,6 +123,9 @@ class StatelessCacheImpl(cache.MutableCache):
     def delete_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
         raise self._no_cache()
 
+    def get_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
+        return None
+
     def get_available_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
         return None
 

--- a/tests/hikari/events/test_message_events.py
+++ b/tests/hikari/events/test_message_events.py
@@ -51,17 +51,15 @@ class TestGuildMessageEvent:
     def test_guild_when_available(self, event):
         result = event.guild
 
-        assert result is event.app.cache.get_available_guild.return_value
-        event.app.cache.get_available_guild.assert_called_once_with(342123123)
-        event.app.cache.get_unavailable_guild.assert_not_called()
+        assert result is event.app.cache.get_guild.return_value
+        event.app.cache.get_guild.assert_called_once_with(342123123)
 
     def test_guild_when_unavailable(self, event):
         event.app.cache.get_available_guild.return_value = None
         result = event.guild
 
-        assert result is event.app.cache.get_unavailable_guild.return_value
-        event.app.cache.get_unavailable_guild.assert_called_once_with(342123123)
-        event.app.cache.get_available_guild.assert_called_once_with(342123123)
+        assert result is event.app.cache.get_guild.return_value
+        event.app.cache.get_guild.assert_called_once_with(342123123)
 
 
 class TestMessageCreateEvent:

--- a/tests/hikari/events/test_typing_events.py
+++ b/tests/hikari/events/test_typing_events.py
@@ -116,10 +116,10 @@ class TestGuildTypingEvent:
 
 
 @pytest.mark.asyncio
-class TestPrivateTypingEvent:
+class TestDMTypingEvent:
     @pytest.fixture()
     def event(self):
-        cls = hikari_test_helpers.mock_class_namespace(typing_events.PrivateTypingEvent)
+        cls = hikari_test_helpers.mock_class_namespace(typing_events.DMTypingEvent)
 
         return cls(
             channel_id=123,

--- a/tests/hikari/impl/test_stateless_cache.py
+++ b/tests/hikari/impl/test_stateless_cache.py
@@ -91,6 +91,9 @@ class TestStatelessCache:
         with pytest.raises(NotImplementedError):
             assert component.delete_guild(123123)
 
+    def test_get_guild(self, component):
+        assert component.get_guild(1234123) is None
+
     def test_get_available_guild(self, component):
         assert component.get_available_guild(1234123) is None
 


### PR DESCRIPTION
* Renamed Private- events to DM- events.
  - Implemented MessageCreateEvent#content and MessageCreateEvent#embeds
  - Implemented get_guild to compliment get_available_guild and get_unavailable_guild on cache.
* Amended README examples.

Fixes #220