### PR TITLE
Snowflakeish types are no longer compatible with 'str' directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async def ping(event: hikari.GuildMessageCreateEvent) -> None:
 bot.run()
 ```
 
-This will only respond to messages created in guilds. You can use `PrivateMessageCreateEvent` 
+This will only respond to messages created in guilds. You can use `PrivateMessageCreateEvent`
 instead to only listen on DMs, or `MessageCreateEvent` to listen to both DMs and guild-based
 messages.
 
@@ -64,10 +64,10 @@ Also note that you could pass extra options to `bot.run` during development, for
 ```py
 bot.run(
     asyncio_debug=True,             # enable asyncio debug to detect blocking and slow code.
-    
-    coroutine_tracking_depth=20,    # enable tracking of coroutines, makes some asyncio 
+
+    coroutine_tracking_depth=20,    # enable tracking of coroutines, makes some asyncio
                                     # errors clearer.
-                                    
+
     propagate_interrupts=True,      # Any OS interrupts get rethrown as errors.
 )
 ```

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -163,7 +163,7 @@ def calculate_shard_id(
     return (int(guild) >> 22) % shard_count
 
 
-Snowflakeish = typing.Union[Snowflake, int, str]
+Snowflakeish = typing.Union[Snowflake, int]
 """Type hint for a value that resembles a `Snowflake` object functionally.
 
 This is a value that is `Snowflake`-ish.
@@ -173,7 +173,6 @@ a `Snowflake`.
 
 The valid types for this type hint are:
 
-- `builtins.str` containing digits.
 - `builtins.int`
 - `Snowflake`
 """
@@ -210,9 +209,6 @@ use of intents).
 
 The valid types for this type hint are:
 
-- `T` - the generic type parameter in the expression
-    `SearchableSnowflakeishOr[T]`
-- `builtins.str` containing digits.
 - `buitlins.int`
 - `Snowflake`
 """
@@ -230,9 +226,6 @@ use of intents).
 
 The valid types for this type hint are:
 
-- `T` - the generic type parameter in the expression
-    `SearchableSnowflakeishOr[T]`
-- `builtins.str` containing digits.
 - `buitlins.int`
 - `Snowflake`
 - `datetime.datetime`


### PR DESCRIPTION
'str' objects must now be cast to a Snowflake or int to be used with compatible functions.

Fixes some points in #197.
