### PR TITLE
Make sure the id of @everyone is always in member.role_ids

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -987,6 +987,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         role_ids = [snowflakes.Snowflake(role_id) for role_id in payload["roles"]]
 
+        # If Discord ever does start including this here without warning we don't want to duplicate the entry.
+        if guild_id not in role_ids:
+            role_ids.insert(0, guild_id)
+
         joined_at = date.iso8601_datetime_string_to_datetime(payload["joined_at"])
 
         raw_premium_since = payload.get("premium_since")

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1430,7 +1430,7 @@ class TestEntityFactoryImpl:
         assert member.guild_id == 76543325
         assert member.user == entity_factory_impl.deserialize_user(user_payload)
         assert member.nickname == "foobarbaz"
-        assert member.role_ids == [11111, 22222, 33333, 44444]
+        assert member.role_ids == [76543325, 11111, 22222, 33333, 44444]
         assert member.joined_at == datetime.datetime(2015, 4, 26, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
         assert member.premium_since == datetime.datetime(2019, 5, 17, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
         assert member.is_deaf is False


### PR DESCRIPTION
### Summary
Make sure the id of @everyone is always in member.role_ids

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
