### PR TITLE
Fix bad logic in clear_members_for_guild

### DIFF
--- a/tests/hikari/impl/test_stateful_cache.py
+++ b/tests/hikari/impl/test_stateful_cache.py
@@ -1927,6 +1927,7 @@ class TestStatefulCacheImpl:
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(42123): cache.GuildRecord(members={snowflakes.Snowflake(67876): mock_member_data})}
         )
+        cache_impl._user_entries = collections.FreezableDict({snowflakes.Snowflake(67876): object()})
         cache_impl._remove_guild_record_if_empty = mock.Mock()
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_member = mock.Mock(return_value=mock_member)


### PR DESCRIPTION
### Summary
Fix bad logic in clear_members_for_guild that Was erroneously trying to get the users objects after garbage collecting them

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
