### PR TITLE
Fix missing conversions for Intervlish fields in rest client

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -174,7 +174,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new bitrate for the channel.
         user_limit : hikari.undefined.UndefinedOr[builtins.int]
             If provided, the new user limit in the channel.
-        rate_limit_per_user : hikari.utilities.time.Intervalish
+        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.utilities.time.Intervalish]
             If provided, the new rate limit per user in the channel.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the new permission overwrites for the channel.
@@ -3019,7 +3019,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        rate_limit_per_user: undefined.UndefinedOr[int] = undefined.UNDEFINED,
+        rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -3045,7 +3045,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the channels topic. Maximum 1024 characters.
         nsfw : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[builtins.int]
+        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.utilities.time.Intervalish]
             If provided, the ammount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
@@ -3094,7 +3094,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        rate_limit_per_user: undefined.UndefinedOr[int] = undefined.UNDEFINED,
+        rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -3120,7 +3120,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the channels topic. Maximum 1024 characters.
         nsfw : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[builtins.int]
+        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.utilities.time.Intervalish]
             If provided, the ammount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -792,7 +792,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("nsfw", nsfw)
         body.put("bitrate", bitrate)
         body.put("user_limit", user_limit)
-        body.put("rate_limit_per_user", rate_limit_per_user)
+        body.put("rate_limit_per_user", rate_limit_per_user, conversion=time.timespan_to_int)
         body.put_snowflake("parent_id", parent_category)
         body.put_array(
             "permission_overwrites",
@@ -1759,7 +1759,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("verification", verification_level)
         body.put("notifications", default_message_notifications)
         body.put("explicit_content_filter", explicit_content_filter_level)
-        body.put("afk_timeout", afk_timeout)
+        body.put("afk_timeout", afk_timeout, conversion=time.timespan_to_int)
         body.put("preferred_locale", preferred_locale, conversion=str)
         body.put_snowflake("afk_channel_id", afk_channel)
         body.put_snowflake("owner_id", owner)
@@ -1824,7 +1824,7 @@ class RESTClientImpl(rest_api.RESTClient):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        rate_limit_per_user: undefined.UndefinedOr[int] = undefined.UNDEFINED,
+        rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -1853,7 +1853,7 @@ class RESTClientImpl(rest_api.RESTClient):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        rate_limit_per_user: undefined.UndefinedOr[int] = undefined.UNDEFINED,
+        rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -1933,7 +1933,7 @@ class RESTClientImpl(rest_api.RESTClient):
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        rate_limit_per_user: undefined.UndefinedOr[int] = undefined.UNDEFINED,
+        rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -1949,7 +1949,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("nsfw", nsfw)
         body.put("bitrate", bitrate)
         body.put("user_limit", user_limit)
-        body.put("rate_limit_per_user", rate_limit_per_user)
+        body.put("rate_limit_per_user", rate_limit_per_user, conversion=time.timespan_to_int)
         body.put_snowflake("category_id", category)
         body.put_array(
             "permission_overwrites",


### PR DESCRIPTION
### Summary
Fix missing conversions for Intervlish fields in rest client
* Fix consistent by typing all "rate_limit_per_user" in the rest client as Intervalish

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #207 
