### PR TITLE
Remove delete_integration rest endpoint as it now dupes leave guild

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -4358,45 +4358,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def delete_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
-        *,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
-        """Delete a guild's integration.
-
-        Parameters
-        ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
-            The guild to delete the integration in. This may be the object
-            or the ID of an existing channel.
-        integration : hikari.snowflakes.SnowflakeishOr[hikari.guilds.Integration]
-            The integration delete. This may be the object
-            or the ID of an existing integration.
-
-        Raises
-        ------
-        hikari.errors.ForbiddenError
-            If you are missing the `MANAGE_GUILD` permission.
-        hikari.errors.UnauthorizedError
-            If you are unauthorized to make the request (invalid/missing token).
-        hikari.errors.NotFoundError
-            If the guild is not found.
-        hikari.errors.RateLimitedError
-            Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
-            rate-limits and global rate-limits. In some rare edge cases,
-            however, Discord implements other undocumented rules for
-            rate-limiting, such as limits per attribute. These cannot be
-            detected or handled normally by Hikari due to their undocumented
-            nature, and will trigger this exception if they occur.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        """
-
-    @abc.abstractmethod
     async def fetch_widget(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> guilds.GuildWidget:
         """Fetch a guilds's widget.
 

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2264,16 +2264,6 @@ class RESTClientImpl(rest_api.RESTClient):
         response = typing.cast(data_binding.JSONArray, raw_response)
         return data_binding.cast_json_array(response, self._entity_factory.deserialize_integration)
 
-    async def delete_integration(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        integration: snowflakes.SnowflakeishOr[guilds.Integration],
-        *,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
-        route = routes.DELETE_GUILD_INTEGRATION.compile(guild=guild, integration=integration)
-        await self._request(route, reason=reason)
-
     async def fetch_widget(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> guilds.GuildWidget:
         route = routes.GET_GUILD_WIDGET.compile(guild=guild)
         raw_response = await self._request(route)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2377,13 +2377,6 @@ class TestRESTClientImplAsync:
             [mock.call({"id": "456"}), mock.call({"id": "789"})]
         )
 
-    async def test_delete_integration(self, rest_client):
-        expected_route = routes.DELETE_GUILD_INTEGRATION.compile(guild=123, integration=456)
-        rest_client._request = mock.AsyncMock()
-
-        await rest_client.delete_integration(StubModel(123), StubModel(456), reason="dont need it anymore")
-        rest_client._request.assert_awaited_once_with(expected_route, reason="dont need it anymore")
-
     async def test_fetch_widget(self, rest_client):
         widget = StubModel(789)
         expected_route = routes.GET_GUILD_WIDGET.compile(guild=123)


### PR DESCRIPTION
### Summary
Remove the delete_integration rest endpoint as it dupes leave guild now that Discord limited it to only targetting the application of the current token(Bot) within the guild.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
