### PR TITLE
Task/deprecating duplicated stub helpers

### DIFF
--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -687,7 +687,7 @@ class GuildChannel(PartialChannel):
         """
         try:
             shard_count = getattr(self.app, "shard_count")
-            assert isinstance(shard_count, int)
+            assert isinstance(shard_count, int), f"shard_count attr was expected to be int, but got {shard_count}"
             return snowflakes.calculate_shard_id(shard_count, self.guild_id)
         except (TypeError, AttributeError, NameError):
             pass

--- a/tests/hikari/events/test_channel_events.py
+++ b/tests/hikari/events/test_channel_events.py
@@ -142,7 +142,7 @@ class TestInviteEvent:
     @pytest.fixture()
     def event(self):
         return hikari_test_helpers.mock_class_namespace(
-            channel_events.InviteEvent, slots=False, code=mock.PropertyMock(return_value="Jx4cNGG")
+            channel_events.InviteEvent, slots_=False, code=mock.PropertyMock(return_value="Jx4cNGG")
         )()
 
     async def test_fetch_invite(self, event):

--- a/tests/hikari/events/test_shard_events.py
+++ b/tests/hikari/events/test_shard_events.py
@@ -28,7 +28,7 @@ class TestMemberChunkEvent:
     def test___getitem___with_slice(self):
         mock_member_0 = object()
         mock_member_1 = object()
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent,
             members={1: object(), 55: object(), 99: mock_member_0, 455: object(), 5444: mock_member_1},
         )
@@ -36,7 +36,7 @@ class TestMemberChunkEvent:
 
     def test___getitem___with_valid_index(self):
         mock_member = object()
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, members={1: object(), 55: object(), 99: mock_member, 455: object()}
         )
         assert event[2] is mock_member
@@ -45,7 +45,7 @@ class TestMemberChunkEvent:
             assert event[55]
 
     def test___getitem___with_invalid_index(self):
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, members={1: object(), 55: object(), 99: object(), 455: object()}
         )
 
@@ -57,13 +57,13 @@ class TestMemberChunkEvent:
         member_1 = object()
         member_2 = object()
 
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, members={234: member_0, 76: member_1, 999: member_2}
         )
         assert list(event) == [member_0, member_1, member_2]
 
     def test___len___(self):
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, members={1: object(), 55: object(), 99: object(), 455: object()}
         )
         assert len(event) == 4

--- a/tests/hikari/hikari_test_helpers.py
+++ b/tests/hikari/hikari_test_helpers.py
@@ -112,7 +112,7 @@ def _stub_init(self, kwargs: typing.Mapping[str, typing.Any]):
 
 
 # TODO: replace all of these with mock_class_namespace
-def stub_class(klass, **kwargs: typing.Any):
+def mock_entire_class_namespace(klass, **kwargs: typing.Any):
     """Get an instance of a class with only attributes provided in the passed kwargs set."""
     if klass not in _stubbed_classes:
         namespace = {"__init__": _stub_init}
@@ -129,20 +129,22 @@ def stub_class(klass, **kwargs: typing.Any):
 
 def mock_class_namespace(
     klass,
+    /,
     *,
-    init: bool = True,
-    slots: typing.Optional[bool] = None,
-    implement_abstract_methods: bool = True,
+    init_: bool = True,
+    slots_: typing.Optional[bool] = None,
+    implement_abstract_methods_: bool = True,
+    rename_impl_: bool = True,
     **namespace: typing.Any,
 ):
     """Get a version of a class with the provided namespace fields set as class attributes."""
-    if slots or slots is None and hasattr(klass, "__slots__"):
+    if slots_ or slots_ is None and hasattr(klass, "__slots__"):
         namespace["__slots__"] = ()
 
-    if init is False:
+    if init_ is False:
         namespace["__init__"] = lambda _: None
 
-    if implement_abstract_methods and hasattr(klass, "__abstractmethods__"):
+    if implement_abstract_methods_ and hasattr(klass, "__abstractmethods__"):
         for method_name in klass.__abstractmethods__:
             if method_name in namespace:
                 continue
@@ -161,7 +163,9 @@ def mock_class_namespace(
     for attribute in namespace.keys():
         assert hasattr(klass, attribute), f"invalid namespace attribute {attribute!r} provided"
 
-    return type("Mock" + klass.__name__, (klass,), namespace)
+    name = "Mock" + klass.__name__ if rename_impl_ else klass.__name__
+
+    return type(name, (klass,), namespace)
 
 
 def retry(max_retries):

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -28,7 +28,7 @@ from tests.hikari import hikari_test_helpers
 class TestTypingIndicator:
     @pytest.fixture()
     def typing_indicator(self):
-        return hikari_test_helpers.mock_class_namespace(special_endpoints.TypingIndicator, init=False)
+        return hikari_test_helpers.mock_class_namespace(special_endpoints.TypingIndicator, init_=False)
 
     def test___enter__(self, typing_indicator):
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative

--- a/tests/hikari/impl/test_stateful_guild_chunker.py
+++ b/tests/hikari/impl/test_stateful_guild_chunker.py
@@ -76,7 +76,7 @@ def stub_chunk_event(mock_app):
 class TestChunkStream:
     @pytest.mark.asyncio
     async def test__listener_when_fails_filter(self, stub_chunk_event, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream, _filters=iterators.All(()), _active=False, _app=mock_app
         )
         stream.filter(lambda _: False)
@@ -85,7 +85,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test__listener_when_fails_passes(self, stub_chunk_event, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _filters=iterators.All(()),
             _active=False,
@@ -102,7 +102,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test__listener_when_queue_filled(self, stub_chunk_event, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _filters=iterators.All(()),
             _active=False,
@@ -122,7 +122,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test__listener_when_chunks_finished(self, stub_chunk_event, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _filters=iterators.All(()),
             _active=False,
@@ -143,7 +143,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___uses_queue_entry(self):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -162,7 +162,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___handles_time_out(self):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -176,7 +176,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___waits_for_initial_chunk(self):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -199,7 +199,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test___anext___when_chunks_depleted(self):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream, _active=True, _queue=asyncio.Queue(), _missing_chunks=[]
         )
 
@@ -208,7 +208,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test___anext___when_stream_not_active(self):
-        stream = hikari_test_helpers.stub_class(stateful_guild_chunker.ChunkStream, _active=False)
+        stream = hikari_test_helpers.mock_entire_class_namespace(stateful_guild_chunker.ChunkStream, _active=False)
 
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative
         with pytest.raises(TypeError):
@@ -216,7 +216,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test_open_for_inactive_stream(self, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _active=False,
             _app=mock_app,
@@ -245,7 +245,7 @@ class TestChunkStream:
 
     @pytest.mark.asyncio
     async def test_open_for_active_stream(self, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker.ChunkStream,
             _active=True,
             _app=mock_app,
@@ -263,12 +263,12 @@ class TestChunkStream:
 
 class TestTrackedChunks:
     def test___copy___when_missing_chunks_is_not_none(self):
-        obj = hikari_test_helpers.stub_class(
+        obj = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker._TrackedRequests,
             missing_chunk_indexes=[5, 6, 7, 8, 9],
             not_found_ids=[2, 4, 6, 7, 8],
         )
-        new_obj = hikari_test_helpers.stub_class(stateful_guild_chunker._TrackedRequests)
+        new_obj = hikari_test_helpers.mock_entire_class_namespace(stateful_guild_chunker._TrackedRequests)
 
         with mock.patch.object(attr_extensions, "copy_attrs", return_value=new_obj):
             result = copy.copy(obj)
@@ -281,10 +281,10 @@ class TestTrackedChunks:
         assert result.not_found_ids is not obj.not_found_ids
 
     def test___copy___when_missing_chunks_is_none(self):
-        obj = hikari_test_helpers.stub_class(
+        obj = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker._TrackedRequests, missing_chunk_indexes=None, not_found_ids=[2, 4, 6, 7, 8]
         )
-        new_obj = hikari_test_helpers.stub_class(stateful_guild_chunker._TrackedRequests)
+        new_obj = hikari_test_helpers.mock_entire_class_namespace(stateful_guild_chunker._TrackedRequests)
 
         with mock.patch.object(attr_extensions, "copy_attrs", return_value=new_obj):
             result = copy.copy(obj)
@@ -294,14 +294,14 @@ class TestTrackedChunks:
 
     def test_is_complete_when_complete(self):
         obj = hikari_test_helpers.mock_class_namespace(
-            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init=False
+            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init_=False
         )()
         obj.chunk_count = 42
         assert obj.is_complete is True
 
     def test_is_complete_when_timed_out(self):
         obj = hikari_test_helpers.mock_class_namespace(
-            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init=False
+            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init_=False
         )()
         obj.chunk_count = 83
         obj._mono_last_received = 3123452134
@@ -314,7 +314,7 @@ class TestTrackedChunks:
 
     def test_is_complete_when_not_timed_out(self):
         obj = hikari_test_helpers.mock_class_namespace(
-            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init=False
+            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init_=False
         )()
         obj.chunk_count = 83
         obj._mono_last_received = 3123452134
@@ -327,7 +327,7 @@ class TestTrackedChunks:
 
     def test_is_complete_when_not_yet_received(self):
         obj = hikari_test_helpers.mock_class_namespace(
-            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init=False
+            stateful_guild_chunker._TrackedRequests, received_chunks=mock.PropertyMock(return_value=42), init_=False
         )()
         obj.chunk_count = 84
         obj._mono_last_received = None
@@ -335,13 +335,13 @@ class TestTrackedChunks:
         assert obj.is_complete is False
 
     def test_received_chunks_when_no_chunks_received_yet(self):
-        obj = hikari_test_helpers.stub_class(
+        obj = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker._TrackedRequests, chunk_count=None, missing_chunk_indexes=None
         )
         assert obj.received_chunks == 0
 
     def test_received_chunks(self):
-        obj = hikari_test_helpers.stub_class(
+        obj = hikari_test_helpers.mock_entire_class_namespace(
             stateful_guild_chunker._TrackedRequests,
             chunk_count=25,
             missing_chunk_indexes=[15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
@@ -487,7 +487,7 @@ class TestStatefulGuildChunkerImpl:
 
     @pytest.mark.asyncio
     async def test_on_chunk_event_for_unknown_shard(self, mock_chunker):
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, shard=mock.Mock(shard.GatewayShardImpl, id=42), nonce="42.hiebye"
         )
         assert await mock_chunker.consume_chunk_event(event) is None
@@ -495,7 +495,7 @@ class TestStatefulGuildChunkerImpl:
 
     @pytest.mark.asyncio
     async def test_on_chunk_event_for_unknown_nonce(self, mock_chunker):
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent, shard=mock.Mock(shard.GatewayShardImpl, id=42), nonce="42.hiebye"
         )
         mock_tracker = object()
@@ -534,7 +534,7 @@ class TestStatefulGuildChunkerImpl:
 
     @pytest.mark.asyncio
     async def test_on_chunk_event_when_initial_tracking_information_set(self, mock_chunker):
-        event = hikari_test_helpers.stub_class(
+        event = hikari_test_helpers.mock_entire_class_namespace(
             shard_events.MemberChunkEvent,
             shard=mock.Mock(shard.GatewayShardImpl, id=4),
             nonce="4.hiebye",
@@ -595,7 +595,7 @@ class TestStatefulGuildChunkerImpl:
     @pytest.mark.parametrize(
         "guild",
         [
-            hikari_test_helpers.stub_class(guilds.GatewayGuild, id=snowflakes.Snowflake(43123)),
+            hikari_test_helpers.mock_entire_class_namespace(guilds.GatewayGuild, id=snowflakes.Snowflake(43123)),
             43123,
             "43123",
             snowflakes.Snowflake(43123),

--- a/tests/hikari/test_applications.py
+++ b/tests/hikari/test_applications.py
@@ -64,8 +64,9 @@ def test_Application_str_operator():
 class TestTeam:
     @pytest.fixture()
     def model(self):
-        klass = hikari_test_helpers.unslot_class(applications.Team)
-        return hikari_test_helpers.stub_class(klass, id=123, icon_hash="ahashicon")
+        return hikari_test_helpers.mock_class_namespace(
+            applications.Team, slots_=False, init_=False, id=123, icon_hash="ahashicon"
+        )()
 
     def test_icon_url_property(self, model):
         model.format_icon = mock.Mock(return_value="url")
@@ -98,8 +99,14 @@ class TestTeam:
 class TestApplication:
     @pytest.fixture()
     def model(self):
-        klass = hikari_test_helpers.unslot_class(applications.Application)
-        return hikari_test_helpers.stub_class(klass, id=123, icon_hash="ahashicon", cover_image_hash="ahashcover")
+        return hikari_test_helpers.mock_class_namespace(
+            applications.Application,
+            init_=False,
+            slots_=False,
+            id=123,
+            icon_hash="ahashicon",
+            cover_image_hash="ahashcover",
+        )()
 
     def test_icon_url_property(self, model):
         model.format_icon = mock.Mock(return_value="url")

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -34,20 +34,23 @@ from tests.hikari import hikari_test_helpers
 
 @pytest.fixture()
 def mock_app():
-    return mock.Mock(bot.BotApp)
+    return mock.Mock(spec_set=bot.BotApp)
 
 
-def test_ChannelType_str_operator():
-    channel_type = channels.ChannelType(1)
-    assert str(channel_type) == "DM"
+class TestChannelType:
+    def test_str_operator(self):
+        channel_type = channels.ChannelType(1)
+        assert str(channel_type) == "DM"
 
 
 class TestChannelFollow:
     @pytest.mark.asyncio
     async def test_fetch_channel(self, mock_app):
-        mock_channel = mock.MagicMock(spec=channels.GuildNewsChannel)
+        mock_channel = mock.Mock(spec=channels.GuildNewsChannel)
         mock_app.rest.fetch_channel = mock.AsyncMock(return_value=mock_channel)
-        follow = channels.ChannelFollow(channel_id=snowflakes.Snowflake(9459234123), app=mock_app, webhook_id=snowflakes.Snowflake(3123123))
+        follow = channels.ChannelFollow(
+            channel_id=snowflakes.Snowflake(9459234123), app=mock_app, webhook_id=snowflakes.Snowflake(3123123)
+        )
 
         result = await follow.fetch_channel()
 
@@ -58,7 +61,9 @@ class TestChannelFollow:
     async def test_fetch_webhook(self, mock_app):
         mock_webhook = object()
         mock_app.rest.fetch_webhook = mock.AsyncMock(return_value=mock_webhook)
-        follow = channels.ChannelFollow(webhook_id=snowflakes.Snowflake(54123123), app=mock_app, channel_id=snowflakes.Snowflake(94949494))
+        follow = channels.ChannelFollow(
+            webhook_id=snowflakes.Snowflake(54123123), app=mock_app, channel_id=snowflakes.Snowflake(94949494)
+        )
 
         result = await follow.fetch_webhook()
 
@@ -67,9 +72,11 @@ class TestChannelFollow:
 
     @pytest.mark.asyncio
     async def test_channel(self, mock_app):
-        mock_channel = mock.MagicMock(spec=channels.GuildNewsChannel)
+        mock_channel = mock.Mock(spec=channels.GuildNewsChannel)
         mock_app.cache.get_guild_channel = mock.Mock(return_value=mock_channel)
-        follow = channels.ChannelFollow(webhook_id=snowflakes.Snowflake(993883), app=mock_app, channel_id=snowflakes.Snowflake(696969))
+        follow = channels.ChannelFollow(
+            webhook_id=snowflakes.Snowflake(993883), app=mock_app, channel_id=snowflakes.Snowflake(696969)
+        )
 
         result = follow.channel
 
@@ -77,152 +84,195 @@ class TestChannelFollow:
         mock_app.cache.get_guild_channel.assert_called_once_with(696969)
 
 
-@pytest.mark.parametrize(("type", "expect_name"), [(0, "ROLE"), (1, "MEMBER")])
-def test_PermissionOverwriteType_str_operator(type, expect_name):
-    overwrite_type = channels.PermissionOverwriteType(type)
-    assert str(overwrite_type) == expect_name
+class TestPermissionOverwrite:
+    @pytest.mark.parametrize(("type", "expect_name"), [(0, "ROLE"), (1, "MEMBER")])
+    def test_str_operator(self, type, expect_name):
+        overwrite_type = channels.PermissionOverwriteType(type)
+        assert str(overwrite_type) == expect_name
+
+    def test_unset(self):
+        overwrite = channels.PermissionOverwrite(
+            type=channels.PermissionOverwriteType.MEMBER, id=snowflakes.Snowflake(1234321)
+        )
+        overwrite._allow = permissions.Permissions.CREATE_INSTANT_INVITE
+        overwrite._deny = permissions.Permissions.CHANGE_NICKNAME
+        assert overwrite.unset == permissions.Permissions(-67108866)
 
 
-def test_PartialChannel_str_operator():
-    mock_channel = mock.Mock(channels.PartialChannel)
-    mock_channel.name = "foo"
-    assert channels.PartialChannel.__str__(mock_channel) == "foo"
+class TestPartialChannel:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return hikari_test_helpers.mock_class_namespace(channels.PartialChannel, rename_impl_=False)(
+            app=mock_app,
+            id=snowflakes.Snowflake(1234567),
+            name="foo",
+            type=channels.ChannelType.GUILD_NEWS,
+        )
+
+    def test_str_operator(self, model):
+        assert str(model) == "foo"
+
+    def test_str_operator_when_name_is_None(self, model):
+        model.name = None
+        assert str(model) == "Unnamed PartialChannel ID 1234567"
 
 
-def test_PartialChannel_str_operator_when_name_is_None():
-    mock_channel = mock.Mock(channels.PartialChannel, id=1234567)
-    mock_channel.name = None
-    assert channels.PartialChannel.__str__(mock_channel) == "Unnamed PartialChannel ID 1234567"
+class TestDMChannel:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return channels.DMChannel(
+            id=snowflakes.Snowflake(12345),
+            name="steve",
+            type=channels.ChannelType.DM,
+            last_message_id=snowflakes.Snowflake(12345),
+            recipient=mock.Mock(spec_set=users.UserImpl, __str__=mock.Mock(return_value="snoop#0420")),
+            app=mock_app,
+        )
+
+    def test_str_operator(self, model):
+        assert str(model) == "DMChannel with: snoop#0420"
+
+    def test_shard_id(self, model):
+        assert model.shard_id == 0
 
 
-def test_DMChannel_str_operator():
-    mock_user = mock.Mock(users.UserImpl, __str__=mock.Mock(return_value="snoop#0420"))
-    mock_user.discriminator = "0420"
-    mock_user.username = "snoop"
-    mock_channel = mock.Mock(channels.DMChannel, recipient=mock_user)
-    assert channels.DMChannel.__str__(mock_channel) == "DMChannel with: snoop#0420"
+class TestGroupDMChannel:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return channels.GroupDMChannel(
+            app=mock_app,
+            id=snowflakes.Snowflake(136134),
+            name="super cool group dm",
+            type=channels.ChannelType.DM,
+            last_message_id=snowflakes.Snowflake(3232),
+            owner_id=snowflakes.Snowflake(1066),
+            icon_hash="1a2b3c",
+            nicknames={
+                snowflakes.Snowflake(1): "person 1",
+                snowflakes.Snowflake(2): "person 2",
+            },
+            recipients={
+                snowflakes.Snowflake(1): mock.Mock(spec_set=users.User, __str__=mock.Mock(return_value="snoop#0420")),
+                snowflakes.Snowflake(2): mock.Mock(spec_set=users.User, __str__=mock.Mock(return_value="yeet#1012")),
+                snowflakes.Snowflake(3): mock.Mock(spec_set=users.User, __str__=mock.Mock(return_value="nice#6969")),
+            },
+            application_id=None,
+        )
+
+    def test_str_operator(self, model):
+        assert str(model) == "super cool group dm"
+
+    def test_str_operator_when_name_is_None(self, model):
+        model.name = None
+        assert str(model) == "GroupDMChannel with: snoop#0420, yeet#1012, nice#6969"
+
+    def test_icon_url(self):
+        channel = hikari_test_helpers.mock_class_namespace(
+            channels.GroupDMChannel, init_=False, format_icon=mock.Mock(return_value="icon-url-here.com")
+        )()
+        assert channel.icon_url == "icon-url-here.com"
+        channel.format_icon.assert_called_once()
+
+    def test_format_icon(self, model):
+        assert model.format_icon(ext="jpeg", size=16) == files.URL(
+            "https://cdn.discordapp.com/channel-icons/136134/1a2b3c.jpeg?size=16"
+        )
+
+    def test_format_icon_without_optional_params(self, model):
+        assert model.format_icon() == files.URL("https://cdn.discordapp.com/channel-icons/136134/1a2b3c.png?size=4096")
+
+    def test_format_icon_when_hash_is_None(self, model):
+        model.icon_hash = None
+        assert model.format_icon() is None
 
 
-def test_DMChannel_shard_id():
-    assert hikari_test_helpers.stub_class(channels.DMChannel).shard_id == 0
+class TestTextChannel:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return hikari_test_helpers.mock_class_namespace(channels.TextChannel)(
+            app=mock_app,
+            id=snowflakes.Snowflake(12345679),
+            name="foo1",
+            type=channels.ChannelType.GUILD_TEXT,
+        )
+
+    @pytest.mark.asyncio
+    async def test_history(self, model):
+        model.app.rest.fetch_messages = mock.AsyncMock()
+
+        await model.history(
+            before=datetime.datetime(2020, 4, 1, 1, 0, 0),
+            after=datetime.datetime(2020, 4, 1, 0, 0, 0),
+            around=datetime.datetime(2020, 4, 1, 0, 30, 0),
+        )
+
+        model.app.rest.fetch_messages.assert_awaited_once_with(
+            12345679,
+            before=datetime.datetime(2020, 4, 1, 1, 0, 0),
+            after=datetime.datetime(2020, 4, 1, 0, 0, 0),
+            around=datetime.datetime(2020, 4, 1, 0, 30, 0),
+        )
+
+    @pytest.mark.asyncio
+    async def test_send(self, model):
+        model.app.rest.create_message = mock.AsyncMock()
+        mock_attachment = object()
+        mock_embed = object()
+        mock_attachments = [object(), object(), object()]
+
+        await model.send(
+            content="test content",
+            nonce="abc123",
+            tts=True,
+            attachment=mock_attachment,
+            attachments=mock_attachments,
+            embed=mock_embed,
+            mentions_everyone=False,
+            user_mentions=[123, 456],
+            role_mentions=[789, 567],
+        )
+
+        model.app.rest.create_message.assert_awaited_once_with(
+            channel=12345679,
+            content="test content",
+            nonce="abc123",
+            tts=True,
+            attachment=mock_attachment,
+            attachments=mock_attachments,
+            embed=mock_embed,
+            mentions_everyone=False,
+            user_mentions=[123, 456],
+            role_mentions=[789, 567],
+        )
 
 
-def test_GroupDMChannel_str_operator():
-    mock_channel = mock.Mock(channels.GroupDMChannel)
-    mock_channel.name = "super cool group dm"
-    assert channels.GroupDMChannel.__str__(mock_channel) == "super cool group dm"
+class TestGuildChannel:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return hikari_test_helpers.mock_class_namespace(channels.GuildChannel)(
+            app=mock_app,
+            id=snowflakes.Snowflake(69420),
+            name="foo1",
+            type=channels.ChannelType.GUILD_VOICE,
+            guild_id=snowflakes.Snowflake(123456789),
+            position=12,
+            permission_overwrites={},
+            is_nsfw=True,
+            parent_id=None,
+        )
 
+    @pytest.mark.parametrize("error", [TypeError, AttributeError, NameError])
+    def test_shard_id_property_when_guild_id_error_raised(self, model, error):
+        class BrokenApp:
+            def __getattr__(self, name):
+                if name == "shard_count":
+                    raise error
+                return mock.Mock()
 
-def test_GroupDMChannel_str_operator_when_name_is_None():
-    user = mock.Mock(users.UserImpl, __str__=mock.Mock(return_value="snoop#0420"))
-    other_user = mock.Mock(users.UserImpl, __str__=mock.Mock(return_value="nice#6969"))
-    mock_channel = mock.Mock(channels.GroupDMChannel, recipients={1: user, 2: other_user})
-    mock_channel.name = None
-    assert channels.GroupDMChannel.__str__(mock_channel) == "GroupDMChannel with: snoop#0420, nice#6969"
+        model.app = BrokenApp()
 
+        assert model.shard_id is None
 
-def test_PermissionOverwrite_unset():
-    overwrite = channels.PermissionOverwrite(type=channels.PermissionOverwriteType.MEMBER, id=1234321)
-    overwrite._allow = permissions.Permissions.CREATE_INSTANT_INVITE
-    overwrite._deny = permissions.Permissions.CHANGE_NICKNAME
-    assert overwrite.unset == permissions.Permissions(-67108866)
-
-
-@pytest.mark.asyncio
-async def test_TextChannel_send():
-    app = mock.Mock()
-    app.rest.create_message = mock.AsyncMock()
-    mock_channel = mock.Mock(channels.TextChannel, id=123, app=app)
-    mock_attachment = object()
-    mock_embed = object()
-    mock_attachments = [object(), object(), object()]
-
-    await channels.TextChannel.send(
-        mock_channel,
-        content="test content",
-        nonce="abc123",
-        tts=True,
-        attachment=mock_attachment,
-        attachments=mock_attachments,
-        embed=mock_embed,
-        mentions_everyone=False,
-        user_mentions=[123, 456],
-        role_mentions=[789, 567],
-    )
-
-    mock_channel.app.rest.create_message.assert_awaited_once_with(
-        channel=123,
-        content="test content",
-        nonce="abc123",
-        tts=True,
-        attachment=mock_attachment,
-        attachments=mock_attachments,
-        embed=mock_embed,
-        mentions_everyone=False,
-        user_mentions=[123, 456],
-        role_mentions=[789, 567],
-    )
-
-
-@pytest.mark.asyncio
-async def test_TextChannel_history():
-    app = mock.Mock()
-    app.rest.fetch_messages = mock.AsyncMock()
-    mock_channel = mock.Mock(channels.TextChannel, id=123, app=app)
-
-    await channels.TextChannel.history(
-        mock_channel,
-        before=datetime.datetime(2020, 4, 1, 1, 0, 0),
-        after=datetime.datetime(2020, 4, 1, 0, 0, 0),
-        around=datetime.datetime(2020, 4, 1, 0, 30, 0),
-    )
-
-    mock_channel.app.rest.fetch_messages.assert_awaited_once_with(
-        123,
-        before=datetime.datetime(2020, 4, 1, 1, 0, 0),
-        after=datetime.datetime(2020, 4, 1, 0, 0, 0),
-        around=datetime.datetime(2020, 4, 1, 0, 30, 0),
-    )
-
-
-def test_GroupDMChannel_icon_url():
-    channel = hikari_test_helpers.mock_class_namespace(
-        channels.GroupDMChannel, init=False, format_icon=mock.Mock(return_value="icon")
-    )()
-    assert channel.icon_url == "icon"
-    channel.format_icon.assert_called_once()
-
-
-def test_GroupDMChannel_format_icon():
-    mock_channel = mock.Mock(channels.GroupDMChannel, id=123, icon_hash="456abc")
-    assert channels.GroupDMChannel.format_icon(mock_channel, ext="jpeg", size=16) == files.URL(
-        "https://cdn.discordapp.com/channel-icons/123/456abc.jpeg?size=16"
-    )
-
-
-def test_GroupDMChannel_format_icon_without_optionals():
-    mock_channel = mock.Mock(channels.GroupDMChannel, id=123, icon_hash="456abc")
-    assert channels.GroupDMChannel.format_icon(mock_channel) == files.URL(
-        "https://cdn.discordapp.com/channel-icons/123/456abc.png?size=4096"
-    )
-
-
-def test_GroupDMChannel_format_icon_when_hash_is_None():
-    mock_channel = mock.Mock(channels.GroupDMChannel, icon_hash=None)
-    assert channels.GroupDMChannel.format_icon(mock_channel) is None
-
-
-def test_GuildChannel_shard_id_property_when_guild_id_is_None():
-    channel = hikari_test_helpers.stub_class(channels.GuildChannel, guild_id=None)
-    assert channel.shard_id is None
-
-
-@pytest.mark.parametrize("error", [TypeError, AttributeError, NameError])
-def test_GuildChannel_shard_id_property_when_guild_id_error_raised(error):
-    channel = hikari_test_helpers.stub_class(channels.GuildChannel, guild_id=mock.Mock(side_effect=error))
-    assert channel.shard_id is None
-
-
-def test_GuildChannel_shard_id_property_when_guild_id_is_not_None():
-    channel = hikari_test_helpers.stub_class(channels.GuildChannel, guild_id=123456789, app=mock.Mock(shard_count=3))
-    assert channel.shard_id == 2
+    def test_shard_id_property_when_guild_id_is_not_None(self, model):
+        model.app.shard_count = 3
+        assert model.shard_id == 2

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -47,7 +47,7 @@ class TestChannelFollow:
     async def test_fetch_channel(self, mock_app):
         mock_channel = mock.MagicMock(spec=channels.GuildNewsChannel)
         mock_app.rest.fetch_channel = mock.AsyncMock(return_value=mock_channel)
-        follow = channels.ChannelFollow(channel_id=snowflakes.Snowflake(9459234123), app=mock_app, webhook_id=3123123)
+        follow = channels.ChannelFollow(channel_id=snowflakes.Snowflake(9459234123), app=mock_app, webhook_id=snowflakes.Snowflake(3123123))
 
         result = await follow.fetch_channel()
 
@@ -58,7 +58,7 @@ class TestChannelFollow:
     async def test_fetch_webhook(self, mock_app):
         mock_webhook = object()
         mock_app.rest.fetch_webhook = mock.AsyncMock(return_value=mock_webhook)
-        follow = channels.ChannelFollow(webhook_id=snowflakes.Snowflake(54123123), app=mock_app, channel_id=94949494)
+        follow = channels.ChannelFollow(webhook_id=snowflakes.Snowflake(54123123), app=mock_app, channel_id=snowflakes.Snowflake(94949494))
 
         result = await follow.fetch_webhook()
 
@@ -69,7 +69,7 @@ class TestChannelFollow:
     async def test_channel(self, mock_app):
         mock_channel = mock.MagicMock(spec=channels.GuildNewsChannel)
         mock_app.cache.get_guild_channel = mock.Mock(return_value=mock_channel)
-        follow = channels.ChannelFollow(webhook_id=993883, app=mock_app, channel_id=snowflakes.Snowflake(696969))
+        follow = channels.ChannelFollow(webhook_id=snowflakes.Snowflake(993883), app=mock_app, channel_id=snowflakes.Snowflake(696969))
 
         result = follow.channel
 

--- a/tests/hikari/test_event_stream.py
+++ b/tests/hikari/test_event_stream.py
@@ -103,7 +103,7 @@ class TestEventStream:
 
     @pytest.mark.asyncio
     async def test___anext___when_stream_closed(self):
-        streamer = hikari_test_helpers.stub_class(event_stream.EventStream, _active=False)
+        streamer = hikari_test_helpers.mock_entire_class_namespace(event_stream.EventStream, _active=False)
 
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative
         with pytest.raises(TypeError):
@@ -112,7 +112,7 @@ class TestEventStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___times_out(self):
-        streamer = hikari_test_helpers.stub_class(
+        streamer = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -129,7 +129,7 @@ class TestEventStream:
     @hikari_test_helpers.timeout()
     async def test___anext___waits_for_next_event(self):
         mock_event = object()
-        streamer = hikari_test_helpers.stub_class(
+        streamer = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -155,7 +155,7 @@ class TestEventStream:
     @hikari_test_helpers.timeout()
     async def test___anext__(self):
         mock_event = object()
-        streamer = hikari_test_helpers.stub_class(
+        streamer = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _active=True,
             _queue=asyncio.Queue(),
@@ -181,7 +181,7 @@ class TestEventStream:
             event_stream.EventStream,
             close=mock.AsyncMock(),
             open=mock.AsyncMock(),
-            init=False,
+            init_=False,
             __anext__=mock.AsyncMock(side_effect=[mock_event_0, mock_event_1, mock_event_2]),
         )()
         streamer._active = False
@@ -192,7 +192,7 @@ class TestEventStream:
     def test___del___for_active_stream(self):
         mock_coroutine = object()
         close_method = mock.Mock(return_value=mock_coroutine)
-        streamer = hikari_test_helpers.mock_class_namespace(event_stream.EventStream, close=close_method, init=False)()
+        streamer = hikari_test_helpers.mock_class_namespace(event_stream.EventStream, close=close_method, init_=False)()
         streamer._event_type = events.Event
         streamer._active = True
 
@@ -210,7 +210,7 @@ class TestEventStream:
 
     def test___del___for_inactive_stream(self):
         close_method = mock.Mock()
-        streamer = hikari_test_helpers.mock_class_namespace(event_stream.EventStream, close=close_method, init=False)()
+        streamer = hikari_test_helpers.mock_class_namespace(event_stream.EventStream, close=close_method, init_=False)()
         streamer._event_type = events.Event
         streamer._active = False
 
@@ -229,7 +229,7 @@ class TestEventStream:
     @pytest.mark.asyncio
     async def test_close_for_active_stream(self, mock_app):
         mock_registered_listener = object()
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _app=mock_app,
             _event_type=events.Event,
@@ -245,7 +245,7 @@ class TestEventStream:
     async def test_close_for_active_stream_handles_value_error(self, mock_app):
         mock_registered_listener = object()
         mock_app.dispatcher.unsubscribe.side_effect = ValueError
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _app=mock_app,
             _event_type=events.Event,
@@ -258,7 +258,9 @@ class TestEventStream:
         assert stream._registered_listener is None
 
     def test_filter_for_inactive_stream(self):
-        stream = hikari_test_helpers.stub_class(event_stream.EventStream, _filters=iterators.All(()), _active=False)
+        stream = hikari_test_helpers.mock_entire_class_namespace(
+            event_stream.EventStream, _filters=iterators.All(()), _active=False
+        )
         first_pass = mock.Mock(attr=True)
         second_pass = mock.Mock(attr=True)
         first_fails = mock.Mock(attr=True)
@@ -276,7 +278,7 @@ class TestEventStream:
 
     @pytest.mark.asyncio
     async def test_filter_for_active_stream(self):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _active=True,
         )
@@ -294,7 +296,7 @@ class TestEventStream:
     @pytest.mark.asyncio
     async def test_open_for_inactive_stream(self, mock_app):
         mock_listener = object()
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _app=mock_app,
             _event_type=events.Event,
@@ -318,7 +320,7 @@ class TestEventStream:
 
     @pytest.mark.asyncio
     async def test_open_for_active_stream(self, mock_app):
-        stream = hikari_test_helpers.stub_class(
+        stream = hikari_test_helpers.mock_entire_class_namespace(
             event_stream.EventStream,
             _app=mock_app,
             _event_type=events.Event,

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -82,14 +82,14 @@ def test_PartialIntegration_str_operator():
 
 
 def test_Role_colour_property():
-    role_obj = hikari_test_helpers.stub_class(guilds.Role, color="color")
+    role_obj = hikari_test_helpers.mock_entire_class_namespace(guilds.Role, color="color")
     assert role_obj.colour == "color"
 
 
 class TestMember:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.stub_class(
+        return hikari_test_helpers.mock_entire_class_namespace(
             guilds.Member,
             user=mock.Mock(
                 users.User,
@@ -195,7 +195,7 @@ class TestMember:
 class TestPartialGuild:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.stub_class(
+        return hikari_test_helpers.mock_entire_class_namespace(
             guilds.PartialGuild, name="hikari", id=1234567890, app=mock.Mock(shard_count=4), icon_hash=None
         )
 
@@ -274,7 +274,9 @@ class TestPartialGuild:
 class TestGuildPreview:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.stub_class(guilds.GuildPreview, id=123, splash_hash=None, discovery_splash_hash=None)
+        return hikari_test_helpers.mock_entire_class_namespace(
+            guilds.GuildPreview, id=123, splash_hash=None, discovery_splash_hash=None
+        )
 
     def test_splash_url(self, obj):
         splash = object()
@@ -336,7 +338,7 @@ class TestGuild:
             get_role = None
             roles = None
 
-        return hikari_test_helpers.stub_class(
+        return hikari_test_helpers.mock_entire_class_namespace(
             StubGuild, id=123, splash_hash=None, discovery_splash_hash=None, banner_hash=None
         )
 

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -18,343 +18,427 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import datetime
+
 import mock
 import pytest
 
+from hikari import colors
 from hikari import guilds
+from hikari import permissions
+from hikari import snowflakes
 from hikari import urls
 from hikari import users
+from hikari.impl import bot
 from hikari.internal import routes
 from tests.hikari import hikari_test_helpers
 
 
-def test_GuildExplicitContentFilterLevel_str_operator():
-    level = guilds.GuildExplicitContentFilterLevel(1)
-    assert str(level) == "MEMBERS_WITHOUT_ROLES"
+@pytest.fixture()
+def mock_app():
+    return mock.Mock(spec_set=bot.BotApp)
 
 
-def test_GuildFeature_str_operator():
-    feature = guilds.GuildFeature("ANIMATED_ICON")
-    assert str(feature) == "ANIMATED_ICON"
+class TestGuildExplicitContentFilterLevel:
+    def test_str_operator(self):
+        level = guilds.GuildExplicitContentFilterLevel(1)
+        assert str(level) == "MEMBERS_WITHOUT_ROLES"
 
 
-def test_GuildMessageNotificationsLevel_str_operator():
-    level = guilds.GuildMessageNotificationsLevel(1)
-    assert str(level) == "ONLY_MENTIONS"
+class TestGuildFeature:
+    def test_str_operator(self):
+        feature = guilds.GuildFeature("ANIMATED_ICON")
+        assert str(feature) == "ANIMATED_ICON"
 
 
-def test_GuildMFALevel_str_operator():
-    level = guilds.GuildMFALevel(1)
-    assert str(level) == "ELEVATED"
+class TestGuildNotificationsLevel:
+    def test_str_operator(self):
+        level = guilds.GuildMessageNotificationsLevel(1)
+        assert str(level) == "ONLY_MENTIONS"
 
 
-def test_GuildPremiumTier_str_operator():
-    level = guilds.GuildPremiumTier(1)
-    assert str(level) == "TIER_1"
+class TestGuildMFALevel:
+    def test_str_operator(self):
+        level = guilds.GuildMFALevel(1)
+        assert str(level) == "ELEVATED"
 
 
-def test_GuildSystemChannelFlag_str_operator():
-    flag = guilds.GuildSystemChannelFlag(1 << 0)
-    assert str(flag) == "SUPPRESS_USER_JOIN"
+class TestGuildPremiumTier:
+    def test_str_operator(self):
+        level = guilds.GuildPremiumTier(1)
+        assert str(level) == "TIER_1"
 
 
-def test_GuildVerificationLevel_str_operator():
-    level = guilds.GuildVerificationLevel(0)
-    assert str(level) == "NONE"
+class TestGuildSystemChannelFlag:
+    def test_str_operator(self):
+        flag = guilds.GuildSystemChannelFlag(1 << 0)
+        assert str(flag) == "SUPPRESS_USER_JOIN"
 
 
-def test_PartialRole_str_operator():
-    mock_role = mock.Mock(guilds.Role)
-    mock_role.name = "The Big Cool"
-    assert guilds.PartialRole.__str__(mock_role) == "The Big Cool"
+class TestGuildVerificationLevel:
+    def test_str_operator(self):
+        level = guilds.GuildVerificationLevel(0)
+        assert str(level) == "NONE"
 
 
-def test_IntegrationAccount_str_operator():
-    mock_account = mock.Mock(guilds.IntegrationAccount)
-    mock_account.name = "your mother"
-    assert guilds.IntegrationAccount.__str__(mock_account) == "your mother"
+class TestPartialRole:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return guilds.PartialRole(
+            app=mock_app,
+            id=snowflakes.Snowflake(1106913972),
+            name="The Big Cool",
+        )
+
+    def test_str_operator(self, model):
+        assert str(model) == "The Big Cool"
 
 
-def test_PartialIntegration_str_operator():
-    mock_integration = mock.Mock(guilds.PartialIntegration)
-    mock_integration.name = "not an integration"
-    assert guilds.PartialIntegration.__str__(mock_integration) == "not an integration"
+class TestIntegrationAccount:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return guilds.IntegrationAccount(id="foo", name="bar")
+
+    def test_str_operator(self, model):
+        assert str(model) == "bar"
 
 
-def test_Role_colour_property():
-    role_obj = hikari_test_helpers.mock_entire_class_namespace(guilds.Role, color="color")
-    assert role_obj.colour == "color"
+class TestPartialIntegration:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return guilds.PartialIntegration(
+            account=mock.Mock(return_value=guilds.IntegrationAccount),
+            id=snowflakes.Snowflake(69420),
+            name="nice",
+            type="illegal",
+        )
+
+    def test_str_operator(self, model):
+        assert str(model) == "nice"
+
+
+class TestRole:
+    @pytest.fixture()
+    def model(self, mock_app):
+        return guilds.Role(
+            app=mock_app,
+            id=snowflakes.Snowflake(979899100),
+            name="@everyone",
+            color=colors.Color(0x1A2B3C),
+            guild_id=snowflakes.Snowflake(112233),
+            is_hoisted=False,
+            is_managed=False,
+            is_mentionable=True,
+            permissions=permissions.Permissions.CONNECT,
+            position=12,
+        )
+
+    def test_colour_property(self, model):
+        assert model.colour == colors.Color(0x1A2B3C)
 
 
 class TestMember:
     @pytest.fixture()
-    def obj(self):
-        return hikari_test_helpers.mock_entire_class_namespace(
-            guilds.Member,
-            user=mock.Mock(
-                users.User,
-                id=123,
-                username="davfsa",
-                discriminator="0001",
-                avatar_url="avatar",
-                avatar_hash="a_12asfdjk1213",
-                default_avatar_url="default avatar",
-                format_avatar=mock.Mock(return_value="formated avatar"),
-                is_bot=False,
-                is_system=True,
-                flags="flags",
-                mention="<@123>",
-                __str__=mock.Mock(return_value="davfsa#0001"),
-            ),
+    def mock_user(self):
+        return mock.Mock(spec_set=users.User, id=snowflakes.Snowflake(123))
+
+    @pytest.fixture()
+    def model(self, mock_user):
+        return guilds.Member(
+            guild_id=snowflakes.Snowflake(456),
+            is_deaf=True,
+            is_mute=True,
+            joined_at=datetime.datetime.now().astimezone(),
             nickname="davb",
-            guild_id=456,
+            premium_since=None,
+            role_ids=[
+                snowflakes.Snowflake(456),
+                snowflakes.Snowflake(1234),
+            ],
+            user=mock_user,
         )
 
-    def test_str_operator(self, obj):
-        assert guilds.Member.__str__(obj) == "davfsa#0001"
+    def test_str_operator(self, model, mock_user):
+        assert str(model) == str(mock_user)
 
-    def test_id_property(self, obj):
-        assert obj.id == 123
+    def test_id_property(self, model, mock_user):
+        assert model.id is mock_user.id
 
-    def test_id_setter_property(self, obj):
+    def test_id_setter_property(self, model):
         with pytest.raises(TypeError):
-            obj.id = 456
+            model.id = 456
 
-    def test_username_property(self, obj):
-        assert obj.username == "davfsa"
+    def test_username_property(self, model, mock_user):
+        assert model.username is mock_user.username
 
-    def test_discriminator_property(self, obj):
-        assert obj.discriminator == "0001"
+    def test_discriminator_property(self, model, mock_user):
+        assert model.discriminator is mock_user.discriminator
 
-    def test_avatar_hash_property(self, obj):
-        assert obj.avatar_hash == "a_12asfdjk1213"
+    def test_avatar_hash_property(self, model, mock_user):
+        assert model.avatar_hash is mock_user.avatar_hash
 
-    def test_is_bot_property(self, obj):
-        assert obj.is_bot is False
+    def test_is_bot_property(self, model, mock_user):
+        assert model.is_bot is mock_user.is_bot
 
-    def test_is_system_property(self, obj):
-        assert obj.is_system is True
+    def test_is_system_property(self, model, mock_user):
+        assert model.is_system is mock_user.is_system
 
-    def test_flags_property(self, obj):
-        assert obj.flags == "flags"
+    def test_flags_property(self, model, mock_user):
+        assert model.flags is mock_user.flags
 
-    def test_avatar_url_property(self, obj):
-        assert obj.avatar_url == "avatar"
+    def test_avatar_url_property(self, model, mock_user):
+        assert model.avatar_url is mock_user.avatar_url
 
-    def test_format_avatar(self, obj):
-        assert obj.format_avatar(ext="png", size=1) == "formated avatar"
-        obj.user.format_avatar.assert_called_once_with(ext="png", size=1)
+    def test_format_avatar(self, model, mock_user):
+        result = model.format_avatar(ext="png", size=4096)
+        mock_user.format_avatar.assert_called_once_with(ext="png", size=4096)
+        assert result is mock_user.format_avatar.return_value
 
-    def test_default_avatar_property(self, obj):
-        assert obj.default_avatar_url == "default avatar"
+    def test_default_avatar_url_property(self, model, mock_user):
+        assert model.default_avatar_url is mock_user.default_avatar_url
 
-    def test_display_name_property_when_nickname(self, obj):
-        assert obj.display_name == "davb"
+    def test_display_name_property_when_nickname(self, model):
+        assert model.display_name == "davb"
 
-    def test_display_name_property_when_no_nickname(self, obj):
-        obj.nickname = None
-        assert obj.display_name == "davfsa"
+    def test_display_name_property_when_no_nickname(self, model, mock_user):
+        model.nickname = None
+        assert model.display_name is mock_user.username
 
-    def test_mention_property_when_nickname(self, obj):
-        assert obj.mention == "<@!123>"
+    def test_mention_property_when_nickname(self, model):
+        assert model.mention == "<@!123>"
 
-    def test_mention_property_when_no_nickname(self, obj):
-        obj.nickname = None
-        assert obj.mention == "<@123>"
+    def test_mention_property_when_no_nickname(self, model, mock_user):
+        model.nickname = None
+        assert model.mention == mock_user.mention
 
-    def test_top_role_when_empty_cache(self, obj):
-        obj.app.cache.get_roles_view_for_guild.return_value = {}
+    def test_top_role_when_empty_cache(self, model):
+        model.app.cache.get_roles_view_for_guild.return_value = {}
 
-        assert obj.top_role is None
+        assert model.top_role is None
 
-        obj.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
+        model.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
 
-    def test_top_role_when_role_ids_not_in_cache(self, obj):
+    def test_top_role_when_role_ids_not_in_cache(self, model):
         role1 = mock.Mock(id=123, position=2)
         role2 = mock.Mock(id=456, position=1)
         mock_cache_view = {123: role1, 456: role2}
-        obj.app.cache.get_roles_view_for_guild.return_value = mock_cache_view
-        obj.role_ids = [321, 654]
+        model.app.cache.get_roles_view_for_guild.return_value = mock_cache_view
+        model.role_ids = [321, 654]
 
-        assert obj.top_role is None
+        assert model.top_role is None
 
-        obj.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
+        model.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
 
-    def test_top_role(self, obj):
+    def test_top_role(self, model):
         role1 = mock.Mock(id=321, position=2)
         role2 = mock.Mock(id=654, position=1)
         mock_cache_view = {321: role1, 654: role2}
-        obj.app.cache.get_roles_view_for_guild.return_value = mock_cache_view
-        obj.role_ids = [321, 654]
+        model.app.cache.get_roles_view_for_guild.return_value = mock_cache_view
+        model.role_ids = [321, 654]
 
-        assert obj.top_role is role1
+        assert model.top_role is role1
 
-        obj.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
+        model.app.cache.get_roles_view_for_guild.assert_called_once_with(456)
 
 
 class TestPartialGuild:
     @pytest.fixture()
-    def obj(self):
-        return hikari_test_helpers.mock_entire_class_namespace(
-            guilds.PartialGuild, name="hikari", id=1234567890, app=mock.Mock(shard_count=4), icon_hash=None
+    def model(self, mock_app):
+        return guilds.PartialGuild(
+            app=mock_app,
+            features=["foo", "bar", "baz"],
+            id=snowflakes.Snowflake(90210),
+            icon_hash="yeet",
+            name="hikari",
         )
 
-    def test_str_operator(self, obj):
-        assert str(obj) == "hikari"
+    def test_str_operator(self, model):
+        assert str(model) == "hikari"
 
-    def test_shard_id_property(self, obj):
-        assert obj.shard_id == 2
+    def test_shard_id_property(self, model):
+        model.app.shard_count = 4
+        assert model.shard_id == 0
 
     @pytest.mark.parametrize("error", [TypeError, AttributeError, NameError])
-    def test_shard_id_property_when_error(self, error, obj):
-        obj.app.shard_count = mock.Mock(spec_set=int, side_effect=error)
+    def test_shard_id_property_when_error(self, error, model):
+        model.app.shard_count = mock.Mock(spec_set=int, side_effect=error)
 
-        assert obj.shard_id is None
+        assert model.shard_id is None
 
-    def test_icon_url(self, obj):
+    def test_icon_url(self, model):
         icon = object()
 
         with mock.patch.object(guilds.PartialGuild, "format_icon", return_value=icon):
-            assert obj.icon_url is icon
+            assert model.icon_url is icon
 
-    def test_format_icon_when_no_hash(self, obj):
-        obj.icon_hash = None
+    def test_format_icon_when_no_hash(self, model):
+        model.icon_hash = None
 
-        assert obj.format_icon(ext="png", size=2) is None
+        assert model.format_icon(ext="png", size=2048) is None
 
-    def test_format_icon_when_format_is_None_and_avatar_hash_is_for_gif(self, obj):
-        obj.icon_hash = "a_18dnf8dfbakfdh"
+    def test_format_icon_when_format_is_None_and_avatar_hash_is_for_gif(self, model):
+        model.icon_hash = "a_yeet"
 
         with mock.patch.object(
             routes, "CDN_GUILD_ICON", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_icon(ext=None, size=2) == "file"
+            assert model.format_icon(ext=None, size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
-            guild_id=1234567890,
-            hash="a_18dnf8dfbakfdh",
-            size=2,
+            guild_id=90210,
+            hash="a_yeet",
+            size=1024,
             file_format="gif",
         )
 
-    def test_format_icon_when_format_is_None_and_avatar_hash_is_not_for_gif(self, obj):
-        obj.icon_hash = "18dnf8dfbakfdh"
-
+    def test_format_icon_when_format_is_None_and_avatar_hash_is_not_for_gif(self, model):
         with mock.patch.object(
             routes, "CDN_GUILD_ICON", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_icon(ext=None, size=2) == "file"
+            assert model.format_icon(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
-            guild_id=1234567890,
-            hash="18dnf8dfbakfdh",
-            size=2,
+            guild_id=90210,
+            hash="yeet",
+            size=4096,
             file_format="png",
         )
 
-    def test_format_icon_with_all_args(self, obj):
-        obj.icon_hash = "18dnf8dfbakfdh"
-
+    def test_format_icon_with_all_args(self, model):
         with mock.patch.object(
             routes, "CDN_GUILD_ICON", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_icon(ext="url", size=2) == "file"
+            assert model.format_icon(ext="url", size=2048) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
-            guild_id=1234567890,
-            hash="18dnf8dfbakfdh",
-            size=2,
+            guild_id=90210,
+            hash="yeet",
+            size=2048,
             file_format="url",
         )
 
 
 class TestGuildPreview:
     @pytest.fixture()
-    def obj(self):
-        return hikari_test_helpers.mock_entire_class_namespace(
-            guilds.GuildPreview, id=123, splash_hash=None, discovery_splash_hash=None
+    def model(self, mock_app):
+        return guilds.GuildPreview(
+            app=mock_app,
+            features=["huge super secret nsfw channel"],
+            id=snowflakes.Snowflake(123),
+            icon_hash="dis is mah icon hash",
+            name="DAPI",
+            splash_hash="dis is also mah splash hash",
+            discovery_splash_hash=None,
+            emojis={},
+            approximate_active_member_count=12,
+            approximate_member_count=999_283_252_124_633,
+            description="the place for quality shitposting!",
         )
 
-    def test_splash_url(self, obj):
+    def test_splash_url(self, model):
         splash = object()
 
         with mock.patch.object(guilds.GuildPreview, "format_splash", return_value=splash):
-            assert obj.splash_url is splash
+            assert model.splash_url is splash
 
-    def test_format_splash_when_hash(self, obj):
-        obj.splash_hash = "18dnf8dfbakfdh"
+    def test_format_splash_when_hash(self, model):
+        model.splash_hash = "18dnf8dfbakfdh"
 
         with mock.patch.object(
             routes, "CDN_GUILD_SPLASH", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_splash(ext="url", size=2) == "file"
+            assert model.format_splash(ext="url", size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
             guild_id=123,
             hash="18dnf8dfbakfdh",
-            size=2,
+            size=1024,
             file_format="url",
         )
 
-    def test_format_splash_when_no_hash(self, obj):
-        assert obj.format_splash(ext="png", size=2) is None
+    def test_format_splash_when_no_hash(self, model):
+        model.splash_hash = None
+        assert model.format_splash(ext="png", size=512) is None
 
-    def test_discovery_splash_url(self, obj):
+    def test_discovery_splash_url(self, model):
         discovery_splash = object()
 
         with mock.patch.object(guilds.GuildPreview, "format_discovery_splash", return_value=discovery_splash):
-            assert obj.discovery_splash_url is discovery_splash
+            assert model.discovery_splash_url is discovery_splash
 
-    def test_format_discovery_splash_when_hash(self, obj):
-        obj.discovery_splash_hash = "18dnf8dfbakfdh"
+    def test_format_discovery_splash_when_hash(self, model):
+        model.discovery_splash_hash = "18dnf8dfbakfdh"
 
         with mock.patch.object(
             routes, "CDN_GUILD_DISCOVERY_SPLASH", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_discovery_splash(ext="url", size=2) == "file"
+            assert model.format_discovery_splash(ext="url", size=2048) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
             guild_id=123,
             hash="18dnf8dfbakfdh",
-            size=2,
+            size=2048,
             file_format="url",
         )
 
-    def test_format_discovery_splash_when_no_hash(self, obj):
-        assert obj.format_discovery_splash(ext="png", size=2) is None
+    def test_format_discovery_splash_when_no_hash(self, model):
+        model.discovery_splash_hash = None
+        assert model.format_discovery_splash(ext="png", size=4096) is None
 
 
 class TestGuild:
     @pytest.fixture()
-    def obj(self):
-        class StubGuild(guilds.Guild):
-            emojis = None
-            get_emoji = None
-            get_role = None
-            roles = None
-
-        return hikari_test_helpers.mock_entire_class_namespace(
-            StubGuild, id=123, splash_hash=None, discovery_splash_hash=None, banner_hash=None
+    def model(self, mock_app):
+        return hikari_test_helpers.mock_class_namespace(guilds.Guild)(
+            app=mock_app,
+            id=snowflakes.Snowflake(123),
+            splash_hash="splash_hash",
+            discovery_splash_hash="discovery_splash_hash",
+            banner_hash="banner_hash",
+            icon_hash="icon_hash",
+            features=[guilds.GuildFeature.ANIMATED_ICON],
+            name="some guild",
+            application_id=snowflakes.Snowflake(9876),
+            afk_channel_id=snowflakes.Snowflake(1234),
+            afk_timeout=datetime.timedelta(seconds=60),
+            default_message_notifications=guilds.GuildMessageNotificationsLevel.ONLY_MENTIONS,
+            description=None,
+            explicit_content_filter=guilds.GuildExplicitContentFilterLevel.ALL_MEMBERS,
+            is_widget_enabled=False,
+            max_video_channel_users=10,
+            mfa_level=guilds.GuildMFALevel.NONE,
+            owner_id=snowflakes.Snowflake(1111),
+            preferred_locale="en-GB",
+            premium_subscription_count=12,
+            premium_tier=guilds.GuildPremiumTier.TIER_3,
+            public_updates_channel_id=None,
+            region="london",
+            rules_channel_id=None,
+            system_channel_id=None,
+            vanity_url_code="yeet",
+            verification_level=guilds.GuildVerificationLevel.VERY_HIGH,
+            widget_channel_id=None,
+            system_channel_flags=guilds.GuildSystemChannelFlag.SUPPRESS_PREMIUM_SUBSCRIPTION,
         )
 
-    def test_splash_url(self, obj):
+    def test_splash_url(self, model):
         splash = object()
 
         with mock.patch.object(guilds.Guild, "format_splash", return_value=splash):
-            assert obj.splash_url is splash
+            assert model.splash_url is splash
 
-    def test_format_splash_when_hash(self, obj):
-        obj.splash_hash = "18dnf8dfbakfdh"
+    def test_format_splash_when_hash(self, model):
+        model.splash_hash = "18dnf8dfbakfdh"
 
         with mock.patch.object(
             routes, "CDN_GUILD_SPLASH", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_splash(ext="url", size=2) == "file"
+            assert model.format_splash(ext="url", size=2) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
@@ -364,55 +448,56 @@ class TestGuild:
             file_format="url",
         )
 
-    def test_format_splash_when_no_hash(self, obj):
-        assert obj.format_splash(ext="png", size=2) is None
+    def test_format_splash_when_no_hash(self, model):
+        model.splash_hash = None
+        assert model.format_splash(ext="png", size=1024) is None
 
-    def test_discovery_splash_url(self, obj):
+    def test_discovery_splash_url(self, model):
         discovery_splash = object()
 
         with mock.patch.object(guilds.Guild, "format_discovery_splash", return_value=discovery_splash):
-            assert obj.discovery_splash_url is discovery_splash
+            assert model.discovery_splash_url is discovery_splash
 
-    def test_format_discovery_splash_when_hash(self, obj):
-        obj.discovery_splash_hash = "18dnf8dfbakfdh"
+    def test_format_discovery_splash_when_hash(self, model):
+        model.discovery_splash_hash = "18dnf8dfbakfdh"
 
         with mock.patch.object(
             routes, "CDN_GUILD_DISCOVERY_SPLASH", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_discovery_splash(ext="url", size=2) == "file"
+            assert model.format_discovery_splash(ext="url", size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
             guild_id=123,
             hash="18dnf8dfbakfdh",
-            size=2,
+            size=1024,
             file_format="url",
         )
 
-    def test_format_discovery_splash_when_no_hash(self, obj):
-        assert obj.format_discovery_splash(ext="png", size=2) is None
+    def test_format_discovery_splash_when_no_hash(self, model):
+        model.discovery_splash_hash = None
+        assert model.format_discovery_splash(ext="png", size=2048) is None
 
-    def test_banner_url(self, obj):
+    def test_banner_url(self, model):
         banner = object()
 
         with mock.patch.object(guilds.Guild, "format_banner", return_value=banner):
-            assert obj.banner_url is banner
+            assert model.banner_url is banner
 
-    def test_format_banner_when_hash(self, obj):
-        obj.banner_hash = "18dnf8dfbakfdh"
-
+    def test_format_banner_when_hash(self, model):
         with mock.patch.object(
             routes, "CDN_GUILD_BANNER", new=mock.Mock(compile_to_file=mock.Mock(return_value="file"))
         ) as route:
-            assert obj.format_banner(ext="url", size=2) == "file"
+            assert model.format_banner(ext="url", size=512) == "file"
 
         route.compile_to_file.assert_called_once_with(
             urls.CDN_URL,
             guild_id=123,
-            hash="18dnf8dfbakfdh",
-            size=2,
+            hash="banner_hash",
+            size=512,
             file_format="url",
         )
 
-    def test_format_banner_when_no_hash(self, obj):
-        assert obj.format_banner(ext="png", size=2) is None
+    def test_format_banner_when_no_hash(self, model):
+        model.banner_hash = None
+        assert model.format_banner(ext="png", size=2048) is None

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -73,6 +73,7 @@ class TestMessage:
         assert message.link == "https://discord.com/channels/@me/456/789"
 
 
+# TODO: this all needs to be moved to one test class.
 @pytest.mark.asyncio
 class TestAsyncMessage:
     async def test_fetch_channel(self, message):

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -56,7 +56,7 @@ def test_Reaction_str_operator():
 
 @pytest.fixture()
 def message():
-    return hikari_test_helpers.stub_class(messages.Message, app=mock.Mock(rest=mock.AsyncMock()))
+    return hikari_test_helpers.mock_entire_class_namespace(messages.Message, app=mock.Mock(rest=mock.AsyncMock()))
 
 
 class TestMessage:

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -41,7 +41,7 @@ def test_PremiumType_str_operator():
 class TestUser:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.mock_class_namespace(users.User, slots=False)()
+        return hikari_test_helpers.mock_class_namespace(users.User, slots_=False)()
 
     def test_avatar_url_when_hash(self, obj):
         avatar = object()
@@ -124,7 +124,7 @@ class TestUser:
 class TestPartialUserImpl:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.stub_class(
+        return hikari_test_helpers.mock_entire_class_namespace(
             users.PartialUserImpl, id=123, username="thomm.o", discriminator="8637", app=mock.Mock()
         )
 
@@ -150,7 +150,7 @@ class TestPartialUserImpl:
 class TestOwnUser:
     @pytest.fixture()
     def obj(self):
-        return hikari_test_helpers.stub_class(users.OwnUser, app=mock.Mock())
+        return hikari_test_helpers.mock_entire_class_namespace(users.OwnUser, app=mock.Mock())
 
     async def test_fetch_self(self, obj):
         user = object()


### PR DESCRIPTION
Rearranging tests that are a bit iffy in structure, and hopefully removing some duplicated test helpers.

So far spotted a couple-dozen issues with invalid arguments being passed around.