### PR TITLE
Implemented default max-retry of 60s.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,4 @@
 [settings]
 profile = black
 force_single_line = true
+skip_glob = **/__init__.pyi

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -121,9 +121,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `READ_MESSAGES` permission in the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -199,6 +205,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing permissions to edit the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -245,6 +254,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             channel.
         hikari.errors.NotFoundError
             If the origin or target channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -275,6 +287,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `MANAGE_CHANNEL` permission in the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -369,6 +384,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the channel is not found or the target is not found if it is
             a role.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -407,6 +425,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `MANAGE_PERMISSIONS` permission in the channel.
         hikari.errors.NotFoundError
             If the channel is not found or the target is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -444,6 +465,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `MANAGE_CHANNEL` permission in the channel.
         hikari.errors.NotFoundError
             If the channel is not found in any guilds you are a member of.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -512,6 +536,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the channel is not found, or if the target user does not exist,
             if provided.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -568,6 +595,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `SEND_MESSAGES` in the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -610,6 +640,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `READ_MESSAGES` in the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -648,6 +681,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the channel is not found, or if the message does not exist in
             the given channel.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -686,6 +722,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the channel is not found or the message is not a pinned message
             in the given channel.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -753,6 +792,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `READ_MESSAGE_HISTORY` in the channel.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -802,6 +844,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the channel is not found or the message is not found in the
             given text channel.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -946,6 +991,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             person you are trying to message has the DM's disabled.
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -995,6 +1043,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             and `MANAGE_MESSAGES` permissions for the target channel.
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1136,6 +1187,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             permission.
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1174,6 +1228,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             not sent by you.
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1267,6 +1324,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             are the first person to add the reaction).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1308,6 +1368,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1351,6 +1414,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1398,6 +1464,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1438,6 +1507,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1489,6 +1561,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel or message is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1548,6 +1623,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1595,6 +1673,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the webhook is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1634,6 +1715,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1672,6 +1756,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1733,6 +1820,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the webhook is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1775,6 +1865,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the webhoook is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1926,6 +2019,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the channel is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1947,6 +2043,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Raises
         ------
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -1972,6 +2071,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2005,6 +2107,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the invite is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2037,6 +2142,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the invite is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2062,6 +2170,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2122,6 +2233,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2170,6 +2284,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If any of the fields that are passed have an invalid value.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2203,6 +2320,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found or you own the guild.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2237,6 +2357,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the user is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2263,6 +2386,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2345,6 +2471,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If you own the guild or the user is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2373,6 +2502,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2406,6 +2538,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the user is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2464,6 +2599,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `VIEW_AUDIT_LOG` permission.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2509,6 +2647,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild or the emoji are not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2544,6 +2685,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2607,6 +2751,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2669,6 +2816,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild or the emoji are not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2707,6 +2857,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild or the emoji are not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2740,6 +2893,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If any of the fields that are passed have an invalid value.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2785,6 +2941,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2821,6 +2980,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found or you are not part of the guild.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2933,6 +3095,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2963,6 +3128,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If you own the guild or if you are not in it.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -2998,6 +3166,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3073,6 +3244,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3148,6 +3322,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3221,6 +3398,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3280,6 +3460,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3317,6 +3500,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3357,6 +3543,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or the user are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3397,6 +3586,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3487,6 +3679,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or the user are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3532,6 +3727,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3581,6 +3779,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild, user or role are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3630,6 +3831,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild, user or role are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3675,6 +3879,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or user are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3729,6 +3936,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or user are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3777,6 +3987,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or user are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3823,6 +4036,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.NotFoundError
             If the guild or user are not found or if the user
             is not banned.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3861,6 +4077,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3897,6 +4116,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -3968,6 +4190,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4004,6 +4229,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4076,6 +4304,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or role are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4113,6 +4344,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild or role are not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4168,6 +4402,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `KICK_MEMBERS` permission.
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4232,6 +4469,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are missing the `KICK_MEMBERS` permission.
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4272,6 +4512,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4310,6 +4553,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4348,6 +4594,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
             If the guild is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4383,6 +4632,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4436,6 +4688,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific
@@ -4471,6 +4726,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If the guild is not found.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
             rate-limits automatically. This includes bucket-specific

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -210,7 +210,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -259,7 +259,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -292,7 +292,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -389,7 +389,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -430,7 +430,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -470,7 +470,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -541,7 +541,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -600,7 +600,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -645,7 +645,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -686,7 +686,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -727,7 +727,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -797,7 +797,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -849,7 +849,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -996,7 +996,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1048,7 +1048,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1192,7 +1192,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1233,7 +1233,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1329,7 +1329,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1373,7 +1373,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1419,7 +1419,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1469,7 +1469,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1512,7 +1512,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1566,7 +1566,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1628,7 +1628,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1678,7 +1678,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1720,7 +1720,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1761,7 +1761,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1825,7 +1825,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -1870,7 +1870,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2024,7 +2024,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2048,7 +2048,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2076,7 +2076,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2112,7 +2112,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2147,7 +2147,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2175,7 +2175,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2238,7 +2238,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2289,7 +2289,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2325,7 +2325,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2362,7 +2362,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2391,7 +2391,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2476,7 +2476,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2507,7 +2507,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2543,7 +2543,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2604,7 +2604,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2652,7 +2652,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2690,7 +2690,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2756,7 +2756,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2821,7 +2821,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2862,7 +2862,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2898,7 +2898,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2946,7 +2946,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -2985,7 +2985,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3100,7 +3100,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3133,7 +3133,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3171,7 +3171,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3249,7 +3249,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3327,7 +3327,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3403,7 +3403,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3465,7 +3465,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3505,7 +3505,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3548,7 +3548,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3591,7 +3591,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3684,7 +3684,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3732,7 +3732,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3784,7 +3784,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3836,7 +3836,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3884,7 +3884,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3941,7 +3941,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -3992,7 +3992,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4041,7 +4041,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4082,7 +4082,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4121,7 +4121,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4195,7 +4195,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4234,7 +4234,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4309,7 +4309,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4349,7 +4349,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4407,7 +4407,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4474,7 +4474,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4517,7 +4517,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4558,7 +4558,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4599,7 +4599,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4637,7 +4637,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4693,7 +4693,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be
@@ -4731,7 +4731,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.RateLimitedError
             Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes bucket-specific
+            rate-limits automatically. This includes most bucket-specific
             rate-limits and global rate-limits. In some rare edge cases,
             however, Discord implements other undocumented rules for
             rate-limiting, such as limits per attribute. These cannot be

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -482,7 +482,7 @@ class RateLimitTooLongError(HTTPError):
     # exists to be self-documenting to the user and for future compatibility
     # only.
     @property
-    def remaining(self) -> typing.Literal[0]:
+    def remaining(self) -> typing.Literal[0]:  # noqa: D401 - Imperative mood
         """The number of requests that are remaining in this window.
 
         This will always be `0` symbolically.

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -180,6 +180,19 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
 
         Note that `"TRACE_HIKARI"` is a library-specific logging level
         which is expected to be more verbose than `"DEBUG"`.
+    max_rate_limit : builtins.float
+        The max number of seconds to backoff for when rate limited. Anything
+        greater than this will instead raise an error.
+
+        This defaults to one minute if left to the default value. This is to
+        stop potentially indefinitely waiting on an endpoint, which is almost
+        never what you want to do if giving a response to a user.
+
+        You can set this to `float("inf")` to disable this check entirely.
+
+        Note that this only applies to the REST API component that communicates
+        with Discord, and will not affect sharding or third party HTTP endpoints
+        that may be in use.
     proxy_settings : typing.Optional[config.ProxySettings]
         Custom proxy settings to use with network-layer logic
         in your application to get through an HTTP-proxy.
@@ -262,6 +275,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
         http_settings: typing.Optional[config.HTTPSettings] = None,
         intents: intents_.Intents = intents_.Intents.ALL_UNPRIVILEGED,
         logs: typing.Union[None, LoggerLevelT, typing.Dict[str, typing.Any]] = "INFO",
+        max_rate_limit: float = 60,
         proxy_settings: typing.Optional[config.ProxySettings] = None,
         rest_url: typing.Optional[str] = None,
     ) -> None:
@@ -325,6 +339,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
             entity_factory=self._entity_factory,
             executor=self._executor,
             http_settings=self._http_settings,
+            max_rate_limit=max_rate_limit,
             proxy_settings=self._proxy_settings,
             rest_url=rest_url,
             token=token,

--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -31,7 +31,7 @@ from nox.sessions import Session
 from pipelines import config
 
 # Default sessions should be defined here
-_options.sessions = ["reformat-code", "pytest", "pdoc3", "pages", "flake8", "mypy", "safety"]
+_options.sessions = ["reformat-code", "pytest", "flake8", "mypy", "safety", "pdoc3", "pages"]
 
 
 def session(*, only_if=lambda: True, reuse_venv: bool = False, **kwargs):

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -41,6 +41,7 @@ from hikari import snowflakes
 from hikari import undefined
 from hikari import urls
 from hikari import users
+from hikari.impl import buckets
 from hikari.impl import entity_factory
 from hikari.impl import rest
 from hikari.impl import special_endpoints
@@ -167,6 +168,7 @@ def rest_app():
         connector_owner=False,
         executor=None,
         http_settings=mock.Mock(spec_set=config.HTTPSettings),
+        max_rate_limit=float("inf"),
         proxy_settings=mock.Mock(spec_set=config.ProxySettings),
         url="https://some.url",
     )
@@ -182,6 +184,7 @@ class TestRESTApp:
                 connector_owner=False,
                 executor=None,
                 http_settings=http_settings,
+                max_rate_limit=float("inf"),
                 proxy_settings=None,
                 url=None,
             )
@@ -224,6 +227,7 @@ class TestRESTApp:
             entity_factory=_entity_factory(),
             executor=rest_app._executor,
             http_settings=rest_app._http_settings,
+            max_rate_limit=float("inf"),
             proxy_settings=rest_app._proxy_settings,
             token="token",
             token_type="Type",
@@ -310,6 +314,7 @@ def rest_client(rest_client_class):
         connector_factory=mock.Mock(),
         connector_owner=False,
         http_settings=mock.Mock(spec=config.HTTPSettings),
+        max_rate_limit=float("inf"),
         proxy_settings=mock.Mock(spec=config.ProxySettings),
         token="some_token",
         token_type="tYpe",
@@ -370,11 +375,29 @@ class StubModel(snowflakes.Unique):
 
 
 class TestRESTClientImpl:
+    def test__init__passes_max_rate_limit(self):
+        with mock.patch.object(buckets, "RESTBucketManager") as bucket:
+            rest.RESTClientImpl(
+                connector_factory=mock.Mock(),
+                connector_owner=True,
+                http_settings=mock.Mock(),
+                max_rate_limit=float("inf"),
+                proxy_settings=mock.Mock(),
+                token=None,
+                token_type=None,
+                rest_url=None,
+                executor=None,
+                entity_factory=None,
+            )
+
+        bucket.assert_called_once_with(float("inf"))
+
     def test__init__when_token_is_None_sets_token_to_None(self):
         obj = rest.RESTClientImpl(
             connector_factory=mock.Mock(),
             connector_owner=True,
             http_settings=mock.Mock(),
+            max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
             token=None,
             token_type=None,
@@ -389,6 +412,7 @@ class TestRESTClientImpl:
             connector_factory=mock.Mock(),
             connector_owner=True,
             http_settings=mock.Mock(),
+            max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
             token="some_token",
             token_type=None,
@@ -403,6 +427,7 @@ class TestRESTClientImpl:
             connector_factory=mock.Mock(),
             connector_owner=True,
             http_settings=mock.Mock(),
+            max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
             token="some_token",
             token_type="tYpe",
@@ -417,6 +442,7 @@ class TestRESTClientImpl:
             connector_factory=mock.Mock(),
             connector_owner=True,
             http_settings=mock.Mock(),
+            max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
             token=None,
             token_type=None,
@@ -431,6 +457,7 @@ class TestRESTClientImpl:
             connector_factory=mock.Mock(),
             connector_owner=True,
             http_settings=mock.Mock(),
+            max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
             token=None,
             token_type=None,


### PR DESCRIPTION
This means if any REST rate limit occurs that lasts more than 60 seconds,
you will instead get a hikari.errors.RateLimitTooLongError get raised
instead which contains details of how long to back off for should you
wish to retry later.

You can disable this functionality by passing `max_rate_limit=float("inf")`
to the `hikari.impl.bot.BotApp` and `hikari.impl.rest.RESTApp` constructors
if you have a reason to not want this. The assumption is that in 99% of
cases, waiting for sustained periods of time would be confusing to the
user and lead to a poorer user experience overall, which is why this has
been implemented.

I still need to fix the tests.

Fixes #264 