### PR TITLE
Moved default Travis CI build stages to use CPython 3.9.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ jobs:
       stage: test
       <<: *windows_test_job
 
+    - name: "Windows 10 CPython 3.10.0-a1 AMD64 Tests"
+      env: PYTHON_VERSION="3.10.0-a1 --pre"
+      arch: amd64
+      stage: test
+      <<: *windows_test_job
+
     - name: "Linux CPython 3.8.5 AMD64 Tests"
       env: PYTHON_IMAGE="python:3.8.5"
       language: ruby
@@ -47,6 +53,20 @@ jobs:
 
     - name: "Linux CPython 3.9.0 AMD64 Tests"
       env: PYTHON_IMAGE="python:3.9.0"
+      language: ruby
+      arch: amd64
+      stage: test
+      <<: *linux_test_job
+
+    - name: "Linux CPython 3.10-rc AMD64 Tests"
+      env: PYTHON_IMAGE="python:3.10-rc"
+      language: ruby
+      arch: amd64
+      stage: test
+      <<: *linux_test_job
+
+    - name: "Linux Stackless Python 3.8.0 AMD64 Tests"
+      env: PYTHON_IMAGE="nekokatt/stackless-python-hikari:3.8.0b3"
       language: ruby
       arch: amd64
       stage: test
@@ -66,10 +86,10 @@ jobs:
       stage: test
       <<: *linux_test_job
 
-    - name: "Linux Stackless Python 3.8.0 AMD64 Tests"
-      env: PYTHON_IMAGE="nekokatt/stackless-python-hikari:3.8.0b3"
+    - name: "Linux CPython 3.10-rc ARM64 Tests"
+      env: PYTHON_IMAGE="python:3.10-rc"
       language: ruby
-      arch: amd64
+      arch: arm64
       stage: test
       <<: *linux_test_job
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ jobs:
       stage: test
       <<: *linux_test_job
 
-    - name: "Linux CPython 3.10-rc AMD64 Tests"
-      env: PYTHON_IMAGE="python:3.10-rc"
-      language: ruby
-      arch: amd64
-      stage: test
-      <<: *linux_test_job
+#    - name: "Linux CPython 3.10-rc AMD64 Tests"
+#      env: PYTHON_IMAGE="python:3.10-rc"
+#      language: ruby
+#      arch: amd64
+#      stage: test
+#      <<: *linux_test_job
 
     - name: "Linux Stackless Python 3.8.0 AMD64 Tests"
       env: PYTHON_IMAGE="nekokatt/stackless-python-hikari:3.8.0b3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,12 +86,12 @@ jobs:
       stage: test
       <<: *linux_test_job
 
-    - name: "Linux CPython 3.10-rc ARM64 Tests"
-      env: PYTHON_IMAGE="python:3.10-rc"
-      language: ruby
-      arch: arm64
-      stage: test
-      <<: *linux_test_job
+#    - name: "Linux CPython 3.10-rc ARM64 Tests"
+#      env: PYTHON_IMAGE="python:3.10-rc"
+#      language: ruby
+#      arch: arm64
+#      stage: test
+#      <<: *linux_test_job
 
     # Linting
     - name: "Linting"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,68 +3,29 @@ stages:
   - deploy
   - webhooks
 
-cache: pip
-
-_test_job: &test_job
-  install:
-    - ${PYTHON_COMMAND} -m pip install nox
-  before_script:
-    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-    - chmod +x ./cc-test-reporter
-    - mkdir public > /dev/null 2>&1 || true
-    - ${PYTHON_COMMAND} -V
-  script:
-    - ${PYTHON_COMMAND} -m nox --sessions pytest
-    # Use --cov-append to make sure coverage covers speedup and non-speedup execution paths equally.
-    - ${PYTHON_COMMAND} -m nox --sessions pytest-speedups -- --cov-append
-  after_script:
-    - bash <(curl -s https://codecov.io/bash)
-    - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-
 _windows_test_job: &windows_test_job
   os: windows
   language: shell
   before_install:
     - choco install --no-progress python --version=${PYTHON_VERSION} -y
-  env:
-    - PYTHON_COMMAND="py -3"
-  <<: *test_job
+  script:
+    - export PYTHON_COMMAND="py -3"
+    - source scripts/test-job.sh
 
 _linux_test_job: &linux_test_job
   os: linux
-  language: python
-  env:
-    - PYTHON_COMMAND=python
-  <<: *test_job
-
-env:
-  global:
-    - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
-    - CC_TEST_REPORTER_ID=bf39911ceca45a536d408ea6456ed67460c73754f1411fb45f5e957398d98348
+  language: shell
+  script:
+    - docker run --mount "type=bind,src=$(pwd),dst=/hikari" "${PYTHON_IMAGE}" /bin/bash -c "cd /hikari && bash /hikari/scripts/test-job.sh"
 
 jobs:
   include:
-    # Linting
-    - name: "Linting"
-      language: python
-      python: "3.9.0"
-      os: linux
-      arch: amd64
-      install: "pip install nox"
-      stage: test
-      script:
-        - python -m nox --sessions safety mypy flake8
-
-    - name: "Twemoji Mapping Verification"
-      language: python
-      python: "3.9.0"
-      os: linux
-      arch: amd64
-      install: "pip install nox"
-      stage: test
-      script:
-        - python -m nox --sessions twemoji-test
-
+    # Testing
+    #
+    # On Windows, we install Python from choco.
+    # On Linux, we use Docker to get the specific version we want, as Travis
+    # is no where near as quick to add newly released versions of Python to
+    # their repos for these jobs as the CPython docker team are to make releases
     - name: "Windows 10 CPython 3.8.5 AMD64 Tests"
       env: PYTHON_VERSION="3.8.5"
       arch: amd64
@@ -78,60 +39,77 @@ jobs:
       <<: *windows_test_job
 
     - name: "Linux CPython 3.8.5 AMD64 Tests"
-      python: "3.8.5"
+      env: PYTHON_IMAGE="python:3.8.5"
+      language: ruby
       arch: amd64
       stage: test
       <<: *linux_test_job
 
     - name: "Linux CPython 3.9.0 AMD64 Tests"
-      python: "3.9.0"
+      env: PYTHON_IMAGE="python:3.9.0"
+      language: ruby
       arch: amd64
       stage: test
       <<: *linux_test_job
 
     - name: "Linux CPython 3.8.5 ARM64 Tests"
-      python: "3.8.5"
+      env: PYTHON_IMAGE="python:3.8.5"
+      language: ruby
       arch: arm64
       stage: test
       <<: *linux_test_job
 
     - name: "Linux CPython 3.9.0 ARM64 Tests"
-      python: "3.9.0"
+      env: PYTHON_IMAGE="python:3.9.0"
+      language: ruby
       arch: arm64
       stage: test
       <<: *linux_test_job
 
     - name: "Linux Stackless Python 3.8.0 AMD64 Tests"
+      env: PYTHON_IMAGE="nekokatt/stackless-python-hikari:3.8.0b3"
       language: ruby
       arch: amd64
       stage: test
+      <<: *linux_test_job
+
+    # Linting
+    - name: "Linting"
+      language: python
+      python: 3.8
+      os: linux
+      arch: amd64
+      install: "pip install nox"
+      stage: test
       script:
-        - >
-          docker run -it \
-              --mount type=bind,src=$(pwd),dst=/hikari \
-              nekokatt/stackless-python-hikari:3.8.0b3 \
-              /bin/bash -c "
-                  set -e
-                  cd /hikari
-                  pip install nox
-                  nox --sessions pytest
-                  bash <(curl -s https://codecov.io/bash)"
+        - python -m nox --sessions safety mypy flake8
+
+    - name: "Twemoji Mapping Verification"
+      language: python
+      python: 3.8
+      os: linux
+      arch: amd64
+      install: "pip install nox"
+      stage: test
+      script:
+        - python -m nox --sessions twemoji-test
 
     - name: "Test building pages"
       if: tag IS NOT present
       stage: test
       language: python
-      python: "3.9.0"
+      python: 3.8
       arch: amd64
       os: linux
       install: pip install nox
       script: nox --sessions pdoc3 pages
 
+    # Deployments
     - name: "Deploy new release"
       if: tag IS present AND tag =~ /^\d+\.\d+\.\d+(\..*)?$/
       stage: deploy
       language: python
-      python: "3.9.0"
+      python: 3.8
       arch: amd64
       os: linux
       script: bash scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     # Linting
     - name: "Linting"
       language: python
-      python: "3.8.5"
+      python: "3.9.0"
       os: linux
       arch: amd64
       install: "pip install nox"
@@ -57,7 +57,7 @@ jobs:
 
     - name: "Twemoji Mapping Verification"
       language: python
-      python: "3.8.5"
+      python: "3.9.0"
       os: linux
       arch: amd64
       install: "pip install nox"
@@ -71,8 +71,8 @@ jobs:
       stage: test
       <<: *windows_test_job
 
-    - name: "Windows 10 CPython 3.9 Dev AMD64 Tests"
-      env: PYTHON_VERSION="3.9.0-rc1 --pre"
+    - name: "Windows 10 CPython 3.9.0 AMD64 Tests"
+      env: PYTHON_VERSION="3.9.0"
       arch: amd64
       stage: test
       <<: *windows_test_job
@@ -83,8 +83,8 @@ jobs:
       stage: test
       <<: *linux_test_job
 
-    - name: "Linux CPython 3.9 Dev AMD64 Tests"
-      python: "3.9-dev"
+    - name: "Linux CPython 3.9.0 AMD64 Tests"
+      python: "3.9.0"
       arch: amd64
       stage: test
       <<: *linux_test_job
@@ -95,8 +95,8 @@ jobs:
       stage: test
       <<: *linux_test_job
 
-    - name: "Linux CPython 3.9 Dev ARM64 Tests"
-      python: "3.9-dev"
+    - name: "Linux CPython 3.9.0 ARM64 Tests"
+      python: "3.9.0"
       arch: arm64
       stage: test
       <<: *linux_test_job
@@ -121,7 +121,7 @@ jobs:
       if: tag IS NOT present
       stage: test
       language: python
-      python: "3.8.5"
+      python: "3.9.0"
       arch: amd64
       os: linux
       install: pip install nox
@@ -131,7 +131,7 @@ jobs:
       if: tag IS present AND tag =~ /^\d+\.\d+\.\d+(\..*)?$/
       stage: deploy
       language: python
-      python: "3.8.5"
+      python: "3.9.0"
       arch: amd64
       os: linux
       script: bash scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ that supports Discord's V8 REST API and Gateway.
 Built on good intentions and the hope that it will be extendable and reusable,
 rather than an obstacle for future development.
 
+Python 3.8, 3.9 and 3.10-dev are currently supported.
+
 ## Bots
 
 ```py

--- a/scripts/test-job.sh
+++ b/scripts/test-job.sh
@@ -9,16 +9,13 @@ mkdir public > /dev/null 2>&1 || true
 ${PYTHON_COMMAND} -V
 ${PYTHON_COMMAND} -m pip install nox
 ${PYTHON_COMMAND} -m nox --sessions pytest
-RESULT_UNOPTIMISED=$?
 ${PYTHON_COMMAND} -m nox --sessions pytest-speedups -- --cov-append
-RESULT_OPTIMISED=$?
-RESULT=$((~$((RESULT_UNOPTIMISED & RESULT_OPTIMISED))))
 
 if [ "$(uname -s | perl -ne 'print lc')-$(uname -m)" = "linux-x86_64" ]; then
     echo "Detected Linux AMD64, will upload coverage data"
     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     chmod +x ./cc-test-reporter
     ./cc-test-reporter after-build \
-        --exit-code ${RESULT} \
+        --exit-code 0 \
         --id       "bf39911ceca45a536d408ea6456ed67460c73754f1411fb45f5e957398d98348"
 fi

--- a/scripts/test-job.sh
+++ b/scripts/test-job.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -x
+
+if [ -z "${PYTHON_COMMAND:+x}" ]; then
+    export PYTHON_COMMAND=python
+fi
+
+mkdir public > /dev/null 2>&1 || true
+${PYTHON_COMMAND} -V
+${PYTHON_COMMAND} -m pip install nox
+${PYTHON_COMMAND} -m nox --sessions pytest
+RESULT_UNOPTIMISED=$?
+${PYTHON_COMMAND} -m nox --sessions pytest-speedups -- --cov-append
+RESULT_OPTIMISED=$?
+RESULT=$((~$((RESULT_UNOPTIMISED & RESULT_OPTIMISED))))
+
+if [ "$(uname -s | perl -ne 'print lc')-$(uname -m)" = "linux-x86_64" ]; then
+    echo "Detected Linux AMD64, will upload coverage data"
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+    ./cc-test-reporter after-build \
+        --exit-code ${RESULT} \
+        --id       "bf39911ceca45a536d408ea6456ed67460c73754f1411fb45f5e957398d98348"
+fi

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         "CI": metadata.ci,
     },
     packages=setuptools.find_namespace_packages(include=[name + "*"]),
-    python_requires=">=3.8.0,<3.10",
+    python_requires=">=3.8.0,<3.11",
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={
         "speedups": parse_requirements_file("speedup-requirements.txt"),
@@ -92,6 +92,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        # TODO: enable when PyPI release with newest trove-classifiers dependency.
+        # "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: Stackless",
         "Topic :: Communications :: Chat",


### PR DESCRIPTION
CPython 3.9.0 was released on Monday (two days ago, 5th October 2020).
