### PR TITLE
Feature/python 3.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,12 @@ jobs:
       stage: test
       <<: *windows_test_job
 
+    - name: "Windows 10 CPython 3.10 Dev AMD64 Tests"
+      env: PYTHON_VERSION="3.10.0-a1 --pre"
+      arch: amd64
+      stage: test
+      <<: *windows_test_job
+
     - name: "Linux CPython 3.8.5 AMD64 Tests"
       python: "3.8.5"
       arch: amd64
@@ -90,6 +96,12 @@ jobs:
       stage: test
       <<: *linux_test_job
 
+    - name: "Linux CPython 3.10 Dev AMD64 Tests"
+      python: "3.10-dev"
+      arch: amd64
+      stage: test
+      <<: *linux_test_job
+
     - name: "Linux CPython 3.8.5 ARM64 Tests"
       python: "3.8.5"
       arch: arm64
@@ -98,6 +110,12 @@ jobs:
 
     - name: "Linux CPython 3.9 Dev ARM64 Tests"
       python: "3.9-dev"
+      arch: arm64
+      stage: test
+      <<: *linux_test_job
+
+    - name: "Linux CPython 3.10 Dev ARM64 Tests"
+      python: "3.10-dev"
       arch: arm64
       stage: test
       <<: *linux_test_job

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         "CI": metadata.ci,
     },
     packages=setuptools.find_namespace_packages(include=[name + "*"]),
-    python_requires=">=3.8.0,<3.10",
+    python_requires=">=3.8.0,<3.11",
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={
         "speedups": parse_requirements_file("speedup-requirements.txt"),
@@ -92,6 +92,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: Stackless",
         "Topic :: Communications :: Chat",


### PR DESCRIPTION
The following needs to be completed:
- [ ] Travis CI need to provide a python-3.10 dev image for Linux AMD64 and ARM64.
- [ ] pypa need to provide a Python 3.10 TROVE classifier (see https://github.com/pypa/trove-classifiers/pull/51 for linked PR requesting this to be implemented).
- Ensure Windows builds pass.
   - [x] AMD64
- Ensure Linux builds pass
   - [ ] AMD64
   - [ ] ARM64